### PR TITLE
Create system that despawns airplanes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ fn main() {
         .add_startup_system(setup_airport)
         .add_startup_system(setup_grid)
         .add_startup_system(spawn_airplane)
+        .add_system(despawn_airplane)
         .add_system(follow_flight_plan)
         .run();
 }

--- a/src/systems/despawn_airplane.rs
+++ b/src/systems/despawn_airplane.rs
@@ -1,0 +1,11 @@
+use bevy::prelude::*;
+
+use crate::components::FlightPlan;
+
+pub fn despawn_airplane(mut commands: Commands, query: Query<(Entity, &FlightPlan)>) {
+    for (entity, flight_plan) in query.iter() {
+        if flight_plan.get().is_empty() {
+            commands.entity(entity).despawn();
+        }
+    }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,9 +1,11 @@
+pub use self::despawn_airplane::*;
 pub use self::follow_flight_plan::*;
 pub use self::setup_airport::*;
 pub use self::setup_camera::*;
 pub use self::setup_grid::*;
 pub use self::spawn_airplane::*;
 
+mod despawn_airplane;
 mod follow_flight_plan;
 mod setup_airport;
 mod setup_camera;


### PR DESCRIPTION
A new system has been added that checks if an airplane has reached its destination, and despawns it if it did. The system deliberately does not check if the airplane has reached the airport, but instead checks if the flight plan has any nodes left. This creates flexibility for future game mechanics, for example random planes crossing the map.

https://user-images.githubusercontent.com/865550/157208444-64c2a5d5-6420-4f9d-8ec9-bc244804c23c.mov

