### PR TITLE
Change the color of airplanes

### DIFF
--- a/src/atc-game/src/systems/spawn_airplane.rs
+++ b/src/atc-game/src/systems/spawn_airplane.rs
@@ -36,7 +36,7 @@ pub fn spawn_airplane(
                     ..Default::default()
                 },
                 sprite: Sprite {
-                    color: Color::BLUE,
+                    color: Color::RED,
                     ..Default::default()
                 },
                 ..Default::default()


### PR DESCRIPTION
The contrast between the black background and the blue airplanes was not
great enough. This made it difficult to spot the planes when sharing
images or videos of the game. Especially in situations where the output
got even further compressed, e.g. when uploading to Twitter, it was
nearly impossible to see the airplanes. Switching the color to red
increases the contrast.