### PR TITLE
Configure default binary

### DIFF
--- a/src/atc-game/Cargo.toml
+++ b/src/atc-game/Cargo.toml
@@ -11,6 +11,8 @@ categories = [
     "games"
 ]
 
+default-run = "atc-game"
+
 publish = false
 
 # See more keys and their definitions at


### PR DESCRIPTION
The `default-run` key has been added to the Cargo manifest and set to the game. This makes it easier to run the game locally during development.