### PR TITLE
Reduce screen size

### DIFF
--- a/src/atc-game/src/main.rs
+++ b/src/atc-game/src/main.rs
@@ -23,10 +23,10 @@ mod store;
 mod systems;
 
 /// The height of the game's window
-const SCREEN_HEIGHT: f32 = 768.0;
+const SCREEN_HEIGHT: f32 = 640.0;
 
 /// The width of the game's window
-const SCREEN_WIDTH: f32 = 1024.0;
+const SCREEN_WIDTH: f32 = 800.0;
 
 /// The dimension of a tile
 ///


### PR DESCRIPTION
The screen size has been reduced to be compatible with our streaming
setup. We are currently streaming parts of the development at 720p, and
are experimenting with different approaches to downscale the display
resolution to the stream. The original size of the game was higher than
the stream, which caused issues with the latest attempt to produce a
sharp stream.

This is only a temporary change during development, and will have to be
reconsidered once we start iterating on the final map size.