### PR TITLE
Measure test coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,7 +100,18 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run tests
-        uses: actions-rs/cargo@v1
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@master
         with:
-          command: test
+          version: 0.18.2
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: cobertura.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+---
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
The test coverage is now collected during CI runs using the tool
tarpaulin. Since tarpaulin only runs on Linux, it has not been
integrated in the local development environment.

Measuring test coverage allows us to identify parts of the code base
that lack tests, and thus might be a source of bugs. Over time and with
regular refactoring sessions, we aim to eventually cover most of the
code base with automated tests.