### PR TITLE
Fix validation of flight plans

### DIFF
--- a/src/atc-game/src/api/airplane.rs
+++ b/src/atc-game/src/api/airplane.rs
@@ -245,7 +245,7 @@ mod tests {
 
         store.insert("AT-4321".into(), airplane);
 
-        let new_flight_plan = FlightPlan::new(vec![Tile::new(0, 0), Tile::new(1, 0)]);
+        let new_flight_plan = FlightPlan::new(vec![Tile::new(1, 0), Tile::new(0, 0)]);
 
         let request = Request::new(UpdateFlightPlanRequest {
             id: "AT-4321".into(),

--- a/src/atc-game/src/components/flight_plan.rs
+++ b/src/atc-game/src/components/flight_plan.rs
@@ -74,7 +74,7 @@ impl FlightPlan {
         &self,
         previous_flight_plan: &FlightPlan,
     ) -> Result<(), ValidationError> {
-        if self.0.get(0) == previous_flight_plan.get().get(0) {
+        if self.0.last() == previous_flight_plan.get().last() {
             Ok(())
         } else {
             Err(ValidationError::InvalidFirstNode)
@@ -126,8 +126,8 @@ mod tests {
     #[test]
     fn validate_with_valid_plan() {
         let previous_flight_plan =
-            FlightPlan(vec![Tile::new(0, 0), Tile::new(1, 0), Tile::new(2, 0)]);
-        let new_flight_plan = FlightPlan(vec![Tile::new(0, 0), Tile::new(1, 0), Tile::new(1, 1)]);
+            FlightPlan(vec![Tile::new(2, 0), Tile::new(1, 0), Tile::new(0, 0)]);
+        let new_flight_plan = FlightPlan(vec![Tile::new(1, 1), Tile::new(1, 0), Tile::new(0, 0)]);
 
         let result = new_flight_plan.validate(&previous_flight_plan);
 
@@ -139,7 +139,7 @@ mod tests {
         let x = *MAP_WIDTH_RANGE.start();
         let y = *MAP_HEIGHT_RANGE.start();
 
-        let previous_flight_plan = FlightPlan(vec![Tile::new(x, y), Tile::new(0, 0)]);
+        let previous_flight_plan = FlightPlan(vec![Tile::new(0, 0), Tile::new(x, y)]);
         let new_flight_plan = FlightPlan(vec![Tile::new(x - 1, y - 1), Tile::new(0, 0)]);
 
         let result = new_flight_plan.validate(&previous_flight_plan);
@@ -195,8 +195,8 @@ mod tests {
 
     #[test]
     fn has_invalid_first_node_with_valid_plan() {
-        let previous_flight_plan = FlightPlan(vec![Tile::new(0, 0), Tile::new(1, 0)]);
-        let new_flight_plan = FlightPlan(vec![Tile::new(0, 0), Tile::new(0, 1)]);
+        let previous_flight_plan = FlightPlan(vec![Tile::new(1, 0), Tile::new(0, 0)]);
+        let new_flight_plan = FlightPlan(vec![Tile::new(0, 1), Tile::new(0, 0)]);
 
         let result = new_flight_plan.has_invalid_first_node(&previous_flight_plan);
 


### PR DESCRIPTION
Flight plans received from the client failed to pass validation, which
upon further investigation revealed a bug in the algorithm. Since flight
plans are stored in reverse order, checking if the next node is the same
has to be done by comparing the last nodes in the lists.