### PR TITLE
Create API to inspect ATC itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "prost",
  "rand",
+ "semver 1.0.6",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2928,7 +2929,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2977,6 +2978,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "semver-parser"

--- a/api/atc/v1/atc.proto
+++ b/api/atc/v1/atc.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package atc.v1;
+
+message Version {
+  uint64 major = 1;
+  uint64 minor = 2;
+  uint64 patch = 3;
+  string pre = 4;
+}
+
+message GetVersionRequest {}
+message GetVersionResponse {
+  Version version = 1;
+}
+
+service AtcService {
+  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse);
+}

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -27,6 +27,7 @@ geo = "0.19.0"
 parking_lot = "0.12.0"
 prost = "0.9.0"
 rand = "0.8.5"
+semver = "1.0.6"
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 tonic = "0.6.2"

--- a/game/src/api/atc.rs
+++ b/game/src/api/atc.rs
@@ -1,0 +1,72 @@
+use semver::Version as SemVer;
+use tonic::{Request, Response, Status};
+
+use atc::v1::{GetVersionRequest, GetVersionResponse, Version};
+
+pub struct AtcService;
+
+#[tonic::async_trait]
+impl atc::v1::atc_service_server::AtcService for AtcService {
+    async fn get_version(
+        &self,
+        _request: Request<GetVersionRequest>,
+    ) -> Result<Response<GetVersionResponse>, Status> {
+        let semver = SemVer::parse(env!("CARGO_PKG_VERSION")).unwrap();
+        let version = Version {
+            major: semver.major,
+            minor: semver.minor,
+            patch: semver.patch,
+            pre: semver.pre.to_string(),
+        };
+
+        Ok(Response::new(GetVersionResponse {
+            version: Some(version),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::Request;
+
+    use atc::v1::atc_service_server::AtcService as ServiceTrait;
+    use atc::v1::GetVersionRequest;
+
+    use super::AtcService;
+
+    #[tokio::test]
+    async fn get_version() {
+        let response = AtcService
+            .get_version(Request::new(GetVersionRequest {}))
+            .await
+            .unwrap();
+
+        let version = response.into_inner().version.unwrap();
+
+        assert_eq!(
+            env!("CARGO_PKG_VERSION_MAJOR").parse::<u64>().unwrap(),
+            version.major
+        );
+        assert_eq!(
+            env!("CARGO_PKG_VERSION_MINOR").parse::<u64>().unwrap(),
+            version.minor
+        );
+        assert_eq!(
+            env!("CARGO_PKG_VERSION_PATCH").parse::<u64>().unwrap(),
+            version.patch
+        );
+        assert_eq!(env!("CARGO_PKG_VERSION_PRE"), version.pre);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AtcService>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AtcService>();
+    }
+}

--- a/game/src/api/mod.rs
+++ b/game/src/api/mod.rs
@@ -4,10 +4,11 @@ use std::sync::Arc;
 
 use tonic::transport::{Error, Server as GrpcServer};
 
-use atc::v1::airplane_service_server::AirplaneServiceServer;
-use atc::v1::event_service_server::EventServiceServer;
-use atc::v1::game_service_server::GameServiceServer;
-use atc::v1::map_service_server::MapServiceServer;
+use ::atc::v1::airplane_service_server::AirplaneServiceServer;
+use ::atc::v1::atc_service_server::AtcServiceServer;
+use ::atc::v1::event_service_server::EventServiceServer;
+use ::atc::v1::game_service_server::GameServiceServer;
+use ::atc::v1::map_service_server::MapServiceServer;
 
 use crate::command::CommandSender;
 use crate::event::EventSender;
@@ -15,11 +16,13 @@ use crate::store::Store;
 use crate::SharedGameState;
 
 use self::airplane::AirplaneService;
+use self::atc::AtcService;
 use self::event::EventService;
 use self::game::GameService;
 use self::map::MapService;
 
 mod airplane;
+mod atc;
 mod event;
 mod game;
 mod map;
@@ -40,6 +43,7 @@ impl Api {
                 command_sender.clone(),
                 store,
             )))
+            .add_service(AtcServiceServer::new(AtcService))
             .add_service(EventServiceServer::new(EventService::new(event_sender)))
             .add_service(GameServiceServer::new(GameService::new(
                 command_sender,


### PR DESCRIPTION
A new API service and endpoint have been created to inspect ATC itself. The only endpoint of the service returns the version of the game, which can be used by clients to determine if they are running on the same version as the server.

The service might be extended in the future to include more information about the game itself as well as its operation.