### PR TITLE
Lint and format shell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,9 @@ insert_final_newline = true
 max_line_length = 80
 trim_trailing_whitespace = true
 
+[bin/*]
+indent_style = tab
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,0 +1,29 @@
+---
+name: Shell
+
+"on": [push]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Lint code with Shellcheck
+        uses: ludeeus/action-shellcheck@1.1.0
+
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run shfmt
+        uses: luizm/action-sh-checker@v0.3.0
+        with:
+          sh_checker_shellcheck_disable: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.0
     hooks:
       - id: prettier
   - repo: https://github.com/doublify/pre-commit-rust
@@ -36,3 +36,10 @@ repos:
       - id: cargo-check
       - id: fmt
         args: [--all, --]
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.6
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+      - id: shfmt
+        name: shfmt

--- a/bin/prepare-release
+++ b/bin/prepare-release
@@ -6,15 +6,15 @@ set -euo pipefail
 IFS=$'\n\t'
 
 if [ $# -ne 1 ]; then
-  echo "Usage: ./prepare-release <next_version>"
-  exit 1
+	echo "Usage: ./prepare-release <next_version>"
+	exit 1
 fi
 
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
 if [ "${current_branch}" != "main" ]; then
-   echo "Releases can only be prepared from the main branch. Aborting"
-   exit 2
+	echo "Releases can only be prepared from the main branch. Aborting"
+	exit 2
 fi
 
 next_version=$1
@@ -22,8 +22,8 @@ current_git_tag="$(git tag -l "v*" | sort | tail -n 1)"
 current_version="$(echo "$current_git_tag" | cut -c 2-)"
 
 if [[ -z "$current_version" ]]; then
-  echo "Failed to get latest version. Aborting"
-  exit 3
+	echo "Failed to get latest version. Aborting"
+	exit 3
 fi
 
 echo "Current version: ${current_version}"
@@ -32,7 +32,7 @@ read -p "Continue? [y/n] " -n 1 -r
 echo
 
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    exit 4
+	exit 4
 fi
 
 echo
@@ -44,14 +44,14 @@ root_directory="$(cd "${bin_directory}/.." || exit 5 && pwd)"
 echo "Bumping version..."
 
 files=(
-  "examples/starter-rust/Cargo.toml"
-  "game/Cargo.toml"
-  "sdk/rust/Cargo.toml"
-  "utilities/debug-client/Cargo.toml"
+	"examples/starter-rust/Cargo.toml"
+	"game/Cargo.toml"
+	"sdk/rust/Cargo.toml"
+	"utilities/debug-client/Cargo.toml"
 )
 
 for file in "${files[@]}"; do
-  vim -c "%s/${current_version}/${next_version}/g" -c "wq" "${root_directory}/${file}"
+	vim -c "%s/${current_version}/${next_version}/g" -c "wq" "${root_directory}/${file}"
 done
 
 # Updating changelog


### PR DESCRIPTION
The developer tooling has been extended to cover shell scripts as well.
shfmt is used to auto-format shell scripts, and shellcheck lints them.