### PR TITLE
Fix style of lists in CHANGELOG

### DIFF
--- a/bin/prepare-release
+++ b/bin/prepare-release
@@ -57,6 +57,7 @@ done
 # Updating changelog
 echo "Updating changelog..."
 
+vim -c "%s/^\* /- /g" -c "wq" "${root_directory}/CHANGELOG.md"
 vim -c "%s!https://github\.com/jdno/atc/pull/\(\d\+\)![#\1](https://github.com/jdno/atc/pull/\1)!g" -c "wq" "${root_directory}/CHANGELOG.md"
 vim -c "%s!@\(\w\+\)![@\1](https://github.com/\1)!g" -c "wq" "${root_directory}/CHANGELOG.md"
 


### PR DESCRIPTION
GitHub generates the auto-generated release notes with the list prefix `*`. This is a style violation in Prettier, which enforces that all lists start with `-`. A new instruction has been added to the pre-release script to convert the list prefixes to the expected format to avoid validation errors.