### PR TITLE
Refactor store to manage all shared state

### DIFF
--- a/game/src/api/airplane.rs
+++ b/game/src/api/airplane.rs
@@ -39,7 +39,7 @@ impl atc::v1::airplane_service_server::AirplaneService for AirplaneService {
     ) -> Result<Response<GetAirplaneResponse>, Status> {
         let id = request.into_inner().id;
 
-        if let Some(airplane) = self.store.get(&id) {
+        if let Some(airplane) = self.store.airplanes().get(&id) {
             Ok(Response::new(GetAirplaneResponse {
                 airplane: Some(airplane.clone()),
             }))
@@ -57,7 +57,7 @@ impl atc::v1::airplane_service_server::AirplaneService for AirplaneService {
         let request = request.into_inner();
         let id = request.id;
 
-        let airplane = match self.store.get(&id) {
+        let airplane = match self.store.airplanes().get(&id) {
             Some(airplane) => airplane,
             None => {
                 return Err(Status::not_found(&format!(
@@ -134,7 +134,7 @@ mod tests {
             flight_plan: flight_plan.as_api(),
         };
 
-        store.insert("AT-4321".into(), airplane);
+        store.airplanes().insert("AT-4321".into(), airplane);
 
         (id, location, flight_plan)
     }
@@ -227,7 +227,7 @@ mod tests {
             flight_plan: flight_plan.as_api(),
         };
 
-        store.insert("AT-4321".into(), airplane);
+        store.airplanes().insert("AT-4321".into(), airplane);
 
         let request = Request::new(UpdateFlightPlanRequest {
             id: "AT-4321".into(),
@@ -252,7 +252,7 @@ mod tests {
             flight_plan: flight_plan.as_api(),
         };
 
-        store.insert("AT-4321".into(), airplane);
+        store.airplanes().insert("AT-4321".into(), airplane);
 
         let new_flight_plan = FlightPlan::new(vec![Node::new(-1, 0), Node::new(0, 0)]);
 

--- a/game/src/api/mod.rs
+++ b/game/src/api/mod.rs
@@ -13,7 +13,6 @@ use ::atc::v1::map_service_server::MapServiceServer;
 use crate::command::CommandSender;
 use crate::event::EventSender;
 use crate::store::Store;
-use crate::SharedGameState;
 
 use self::airplane::AirplaneService;
 use self::atc::AtcService;
@@ -35,19 +34,18 @@ impl Api {
     pub async fn serve(
         command_sender: CommandSender,
         event_sender: EventSender,
-        game_state: SharedGameState,
         store: Arc<Store>,
     ) -> Result<(), Error> {
         GrpcServer::builder()
             .add_service(AirplaneServiceServer::new(AirplaneService::new(
                 command_sender.clone(),
-                store,
+                store.clone(),
             )))
             .add_service(AtcServiceServer::new(AtcService))
             .add_service(EventServiceServer::new(EventService::new(event_sender)))
             .add_service(GameServiceServer::new(GameService::new(
                 command_sender,
-                game_state,
+                store,
             )))
             .add_service(MapServiceServer::new(MapService))
             .serve(Self::address_or_default())

--- a/game/src/state/mod.rs
+++ b/game/src/state/mod.rs
@@ -1,40 +1,5 @@
-use crate::event::EventReceiver;
-use crate::{Event, SharedGameState};
-use atc::v1::get_game_state_response::GameState;
-
 pub use self::ready::GameStateReadyPlugin;
 pub use self::running::GameStateRunningPlugin;
 
 mod ready;
 mod running;
-
-#[derive(Debug)]
-pub struct GameStateWatcher {
-    event_bus: EventReceiver,
-    game_state: SharedGameState,
-}
-
-impl GameStateWatcher {
-    pub fn new(event_bus: EventReceiver, game_state: SharedGameState) -> Self {
-        Self {
-            event_bus,
-            game_state,
-        }
-    }
-
-    pub async fn connect(&mut self) {
-        while let Ok(event) = self.event_bus.recv().await {
-            match event {
-                Event::GameStarted(_) => {
-                    let mut game_started = self.game_state.lock();
-                    *game_started = GameState::Running;
-                }
-                Event::GameStopped => {
-                    let mut game_started = self.game_state.lock();
-                    *game_started = GameState::Ready;
-                }
-                _ => {}
-            }
-        }
-    }
-}

--- a/game/src/store/mod.rs
+++ b/game/src/store/mod.rs
@@ -1,9 +1,69 @@
-use dashmap::DashMap;
+use std::sync::Arc;
 
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use atc::v1::get_game_state_response::GameState;
 use atc::v1::Airplane;
+
+use crate::map::Map;
 
 pub use self::watcher::StoreWatcher;
 
 mod watcher;
 
-pub type Store = DashMap<String, Airplane>;
+pub type SharedGameState = Arc<Mutex<GameState>>;
+pub type SharedMap = Arc<Mutex<Map>>;
+
+#[derive(Clone, Debug)]
+pub struct Store {
+    airplanes: DashMap<String, Airplane>,
+    game_state: SharedGameState,
+    map: SharedMap,
+}
+
+impl Store {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // TODO: Hide implementation details (DashMap) and provide query interface for airplanes
+    pub fn airplanes(&self) -> &DashMap<String, Airplane> {
+        &self.airplanes
+    }
+
+    pub fn game_state(&self) -> &SharedGameState {
+        &self.game_state
+    }
+
+    pub fn map(&self) -> &SharedMap {
+        &self.map
+    }
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Self {
+            airplanes: DashMap::new(),
+            game_state: Arc::new(Mutex::new(GameState::Ready)),
+            map: Arc::new(Mutex::new(Map::new())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Store;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Store>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Store>();
+    }
+}


### PR DESCRIPTION
The store has been refactored to not only manage airplanes but also the
game state and the map. This makes it the single source of truth for all
shared data. Another benefit is that there is only a single place that
needs to be reset between games now.

Airplanes are still stored in a DashMap, while the game state and the
map are placed inside a shared mutex. Both are mostly read, and only
barely written, so there shouldn't be any performance issues with this
choice.

The store watcher has been refactored as well to take over the
responsibilities of the game state watcher, which in turn has been
removed. This again centralizes all state management in a single
location.