### PR TITLE
Create API to query the map

### DIFF
--- a/api/atc/v1/map.proto
+++ b/api/atc/v1/map.proto
@@ -16,6 +16,11 @@ message Point {
   int32 y = 2;
 }
 
+message GetMapRequest {}
+message GetMapResponse {
+  Map map = 1;
+}
+
 message NodeToPointRequest {
   Node node = 1;
 }
@@ -25,5 +30,6 @@ message NodeToPointResponse {
 }
 
 service MapService {
+  rpc GetMap(GetMapRequest) returns (GetMapResponse);
   rpc NodeToPoint(NodeToPointRequest) returns (NodeToPointResponse);
 }

--- a/game/src/api/mod.rs
+++ b/game/src/api/mod.rs
@@ -45,9 +45,9 @@ impl Api {
             .add_service(EventServiceServer::new(EventService::new(event_sender)))
             .add_service(GameServiceServer::new(GameService::new(
                 command_sender,
-                store,
+                store.clone(),
             )))
-            .add_service(MapServiceServer::new(MapService))
+            .add_service(MapServiceServer::new(MapService::new(store)))
             .serve(Self::address_or_default())
             .await
     }


### PR DESCRIPTION
A new API method has been created that retrieves the map from the game. The map service gets the map from the shared store, converts it into the API representation, and then returns it.