### PR TITLE
Add routing grid to map data in API responses

### DIFF
--- a/api/atc/v1/map.proto
+++ b/api/atc/v1/map.proto
@@ -4,6 +4,7 @@ package atc.v1;
 
 message Map {
   Node airport = 1;
+  repeated Node routing_grid = 2;
 }
 
 message Node {

--- a/game/src/map/mod.rs
+++ b/game/src/map/mod.rs
@@ -66,6 +66,7 @@ impl AsApi for Map {
     fn as_api(&self) -> Self::ApiType {
         ApiMap {
             airport: Some(self.airport.as_api()),
+            routing_grid: self.routing_grid.iter().map(|node| node.as_api()).collect(),
         }
     }
 }


### PR DESCRIPTION
The routing grid is now part of the map message type in API responses. This enables players to implement path finding algorithms based on the map.