### PR TITLE
Add width and height to map message type

### DIFF
--- a/api/atc/v1/map.proto
+++ b/api/atc/v1/map.proto
@@ -12,6 +12,8 @@ message Airport {
 message Map {
   repeated Airport airports = 1;
   repeated Node routing_grid = 2;
+  uint32 width = 3;
+  uint32 height = 4;
 }
 
 message Node {

--- a/game/src/map/mod.rs
+++ b/game/src/map/mod.rs
@@ -78,6 +78,8 @@ impl AsApi for Map {
                 .map(|airport| airport.as_api())
                 .collect(),
             routing_grid: self.routing_grid.iter().map(|node| node.as_api()).collect(),
+            width: MAP_WIDTH as u32,
+            height: MAP_HEIGHT as u32,
         }
     }
 }


### PR DESCRIPTION
The map message type in the API has been extended to include the dimensions of the map. This makes it easier for clients to index the array of routing nodes.