### PR TITLE
Normalize speed when flying diagonally

### DIFF
--- a/game/src/systems/follow_flight_plan.rs
+++ b/game/src/systems/follow_flight_plan.rs
@@ -83,7 +83,7 @@ fn fly(
             return true;
         } else {
             let direction = Direction::between(&next_point, &current_point);
-            *current_position += direction.to_vec3() * travelled_distance;
+            *current_position += direction.to_vec3().normalize() * travelled_distance;
         }
     }
 


### PR DESCRIPTION
When flying diagonally between nodes, planes were faster than when
flying either horizontally or vertically. The direction vector is now
normalized to prevent this behavior, and to ensure that planes fly with
a constant speed.