### PR TITLE
Spawn airplanes outside of the visible map

### DIFF
--- a/game/src/components/location.rs
+++ b/game/src/components/location.rs
@@ -59,6 +59,15 @@ impl From<&Mut<'_, bevy::prelude::Transform>> for Location {
     }
 }
 
+impl From<&Vec3> for Location {
+    fn from(vec3: &Vec3) -> Self {
+        Self {
+            x: vec3.x as i32,
+            y: vec3.y as i32,
+        }
+    }
+}
+
 impl Display for Location {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "Location {{ x: {}, y: {} }}", self.x, self.y)

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -5,7 +5,7 @@ use tokio::sync::broadcast::{channel, Receiver};
 
 use crate::api::Api;
 use crate::command::Command;
-use crate::event::{Event, EventBus};
+use crate::event::Event;
 use crate::scene::{GameOverPlugin, GamePlugin, MainMenuPlugin};
 use crate::store::{Store, StoreWatcher};
 use crate::systems::*;

--- a/game/src/systems/generate_flight_plan.rs
+++ b/game/src/systems/generate_flight_plan.rs
@@ -30,8 +30,7 @@ pub fn generate_flight_plan(
     }
 }
 
-// TODO: Refactor into a shared module
-pub fn generate_random_plan(travelled_route: &TravelledRoute, map: &Res<Map>) -> FlightPlan {
+fn generate_random_plan(travelled_route: &TravelledRoute, map: &Res<Map>) -> FlightPlan {
     let mut flight_plan = Vec::new();
 
     let mut reversed_route = travelled_route.get().iter().rev();


### PR DESCRIPTION
Airplanes are now spawned just outside the visible area of the map. They fly onto the map, and don't just randomly appear on a routing node. This also gives the player more time to avoid collisions around the edge of the map.

https://user-images.githubusercontent.com/865550/160407809-9bdde51d-76c6-4c01-b23a-883c01cdc535.mov

