### PR TITLE
Change domain

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 const config = {
   title: "Auto Traffic Control",
   tagline: "A Video Game for Programmers",
-  url: "https://autotrafficcontrol.com",
+  url: "https://auto-traffic-control.com",
   baseUrl: "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,1 @@
-autotrafficcontrol.com
+auto-traffic-control.com


### PR DESCRIPTION
The domain has been changed from `autotrafficcontrol.com` to the more
consistent `auto-traffic-control`. With this change, the domain is the
same as the package names. The old domain has been configured to
redirect to the new one.