### PR TITLE
Run GitHub Actions only when necessary

### DIFF
--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -1,7 +1,10 @@
 ---
 name: Documentation
 
-"on": [push]
+"on":
+  push:
+    paths:
+      - "docs/**"
 
 jobs:
   build:

--- a/.github/workflows/push-json.yml
+++ b/.github/workflows/push-json.yml
@@ -1,7 +1,10 @@
 ---
 name: JSON
 
-"on": [push]
+"on":
+  push:
+    paths:
+      - "**.json"
 
 jobs:
   style:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,5 +1,5 @@
 ---
-name: main
+name: Maintenance
 
 "on":
   push:

--- a/.github/workflows/push-markdown.yml
+++ b/.github/workflows/push-markdown.yml
@@ -1,7 +1,10 @@
 ---
 name: Markdown
 
-"on": [push]
+"on":
+  push:
+    paths:
+      - "**.md"
 
 jobs:
   lint:

--- a/.github/workflows/push-protobuf.yml
+++ b/.github/workflows/push-protobuf.yml
@@ -1,7 +1,10 @@
 ---
 name: Protobuf
 
-"on": [push]
+"on":
+  push:
+    paths:
+      - "api/**.proto"
 
 jobs:
   lint:

--- a/.github/workflows/push-rust.yml
+++ b/.github/workflows/push-rust.yml
@@ -1,7 +1,11 @@
 ---
 name: Rust
 
-"on": [push]
+"on":
+  push:
+    paths:
+      - "**.rs"
+      - "**.toml"
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/push-shell.yml
+++ b/.github/workflows/push-shell.yml
@@ -1,7 +1,11 @@
 ---
 name: Shell
 
-"on": [push]
+"on":
+  push:
+    paths:
+      - "**.sh"
+      - "bin/**"
 
 jobs:
   lint:

--- a/.github/workflows/push-yaml.yml
+++ b/.github/workflows/push-yaml.yml
@@ -1,7 +1,11 @@
 ---
 name: YAML
 
-"on": [push]
+"on":
+  push:
+    paths:
+      - "**.yaml"
+      - "**.yml"
 
 jobs:
   lint:


### PR DESCRIPTION
Right now, the continuous integration pipeline on GitHub Actions is run
whenever code is pushed to GitHub. Especially the Rust builds take quite
a while, slowing down the iteration speed on pull requests and using up
valuable build minutes.

The actions have been changed to only run when the files that they check
have actually been touched. This implementation is a first attempt to
make CI more efficient, and may not fully work as expected.