### PR TITLE
Enable dependency updates for documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,37 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
     labels:
       - C-dependency
+      - L-github
       - R-ignore
 
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
     labels:
       - C-dependency
+      - L-rust
+      - R-ignore
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
+    labels:
+      - C-dependency
+      - L-node
       - R-ignore

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,6 +11,15 @@
 - name: C-feature-request
   color: e74c3c
   description: "Request a new feature"
+- name: L-github
+  color: 34495e
+  description: "Tag the GitHub ecosystem"
+- name: L-node
+  color: 34495e
+  description: "Tag the Node ecosystem"
+- name: L-rust
+  color: 34495e
+  description: "Tag the Rust ecosystem"
 - name: R-added
   color: 95a5a6
   description: "Add a new feature to the release notes"


### PR DESCRIPTION
The configuration of Dependabot has been extended to cover the
documentation as well. To make it easier to review the pull requests, a
new label for the ecosystem have been added and PRs are now assigned to
`jdno`, the maintainer of the project.