### PR TITLE
Create test server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,6 +3377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-server"
+version = "0.2.0"
+dependencies = [
+ "auto-traffic-control",
+ "prost",
+ "semver 1.0.7",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ members = [
     "examples/starter-rust",
     "sdk/rust",
     "utilities/debug-client",
+    "utilities/test-server",
 ]

--- a/bin/prepare-release
+++ b/bin/prepare-release
@@ -49,6 +49,7 @@ files=(
 	"sdk/rust/Cargo.toml"
 	"sdk/rust/README.md"
 	"utilities/debug-client/Cargo.toml"
+	"utilities/test-server/Cargo.toml"
 )
 
 for file in "${files[@]}"; do

--- a/utilities/test-server/Cargo.toml
+++ b/utilities/test-server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test-server"
+license = "MIT OR Apache-2.0"
+version = "0.2.0"
+edition = "2021"
+
+rust-version = "1.56"
+
+description = "Run a mock server for integration tests"
+repository = "https://github.com/jdno/auto-traffic-control"
+
+publish = false
+
+# See more keys and their definitions at
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+auto-traffic-control = { path = "../../sdk/rust", version = "0.2.0", features = ["server"] }
+
+prost = "0.10.1"
+semver = "1.0.7"
+tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
+tonic = "0.7.1"

--- a/utilities/test-server/src/main.rs
+++ b/utilities/test-server/src/main.rs
@@ -1,0 +1,41 @@
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use semver::Version as SemVer;
+use tonic::transport::{Error, Server};
+use tonic::{Request, Response, Status};
+
+use auto_traffic_control::v1::atc_service_server::AtcServiceServer;
+use auto_traffic_control::v1::{GetVersionRequest, GetVersionResponse, Version};
+
+struct AtcService;
+
+#[tonic::async_trait]
+impl auto_traffic_control::v1::atc_service_server::AtcService for AtcService {
+    async fn get_version(
+        &self,
+        _request: Request<GetVersionRequest>,
+    ) -> Result<Response<GetVersionResponse>, Status> {
+        let semver = SemVer::parse(env!("CARGO_PKG_VERSION")).unwrap();
+        let version = Version {
+            major: semver.major,
+            minor: semver.minor,
+            patch: semver.patch,
+            pre: semver.pre.to_string(),
+        };
+
+        Ok(Response::new(GetVersionResponse {
+            version: Some(version),
+        }))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    Server::builder()
+        .add_service(AtcServiceServer::new(AtcService))
+        .serve(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(0, 0, 0, 0),
+            4747,
+        )))
+        .await
+}


### PR DESCRIPTION
A server has been created that can be used to run integration tests for the different SDKs. The test server implements a single gRPC service from the project's Protocol Buffers, and returns a pre-defined response that can be matched against in tests.