### PR TITLE
Switch to new variant to access world resources

### DIFF
--- a/game/src/command/bus.rs
+++ b/game/src/command/bus.rs
@@ -19,7 +19,7 @@ impl CommandBus {
 
 impl FromWorld for CommandBus {
     fn from_world(world: &mut World) -> Self {
-        let sender = world.get_resource::<CommandSender>().unwrap();
+        let sender = world.resource::<CommandSender>();
 
         Self {
             receiver: sender.subscribe(),

--- a/game/src/event/bus.rs
+++ b/game/src/event/bus.rs
@@ -19,7 +19,7 @@ impl EventBus {
 
 impl FromWorld for EventBus {
     fn from_world(world: &mut World) -> Self {
-        let sender = world.get_resource::<EventSender>().unwrap();
+        let sender = world.resource::<EventSender>();
 
         Self {
             sender: sender.clone(),


### PR DESCRIPTION
The Bevy team noticed that most invocations of `get_resource` were
followed by an immediate `unwrap`. A new API [^1] was introduced that
panics internally, thus avoiding the need for users to unwrap
themselves. The old API still remains for users who want to handle
the `Option` manually.

In our case, we want to panic if the message buses cannot be accessed.
The game cannot work properly without them, and the caller has no way of
fixing the problem.

[^1]: https://bevyengine.org/news/bevy-0-7/#world-resource