### PR TITLE
Enable Dependabot for Node SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,42 @@ updates:
       - C-dependency
       - L-node
       - R-ignore
+
+  - package-ecosystem: "npm"
+    directory: "/examples/javascript"
+    schedule:
+      interval: "daily"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
+    labels:
+      - C-dependency
+      - L-node
+      - R-ignore
+
+  - package-ecosystem: "npm"
+    directory: "/examples/typescript"
+    schedule:
+      interval: "daily"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
+    labels:
+      - C-dependency
+      - L-node
+      - R-ignore
+
+  - package-ecosystem: "npm"
+    directory: "/sdk/node"
+    schedule:
+      interval: "daily"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
+    labels:
+      - C-dependency
+      - L-node
+      - R-ignore


### PR DESCRIPTION
The dependencies of the Node SDK and its examples are now automatically updated through Dependabot.