### PR TITLE
Re-export missing ServiceError type

### DIFF
--- a/examples/typescript/main.ts
+++ b/examples/typescript/main.ts
@@ -3,13 +3,14 @@ import {
   AtcServiceClient,
   GetVersionRequest,
   GetVersionResponse,
+  ServiceError,
 } from "auto-traffic-control";
 
 const atcService = new AtcServiceClient("localhost:4747", getCredentials());
 
 atcService.getVersion(
   new GetVersionRequest(),
-  (err, response: GetVersionResponse) => {
+  (err: ServiceError | null, response: GetVersionResponse) => {
     if (err != null) {
       throw err;
     }

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -1,4 +1,4 @@
-import { credentials, ChannelCredentials } from "@grpc/grpc-js";
+import { credentials, ChannelCredentials, ServiceError } from "@grpc/grpc-js";
 
 export * from "./atc/v1/airplane_pb";
 export * from "./atc/v1/airplane_grpc_pb";
@@ -11,6 +11,8 @@ export * from "./atc/v1/game_grpc_pb";
 export * from "./atc/v1/map_pb";
 export * from "./atc/v1/map_grpc_pb";
 export * from "./atc/v1/tag_pb";
+
+export { ChannelCredentials, ServiceError };
 
 export function getCredentials(): ChannelCredentials {
   return credentials.createInsecure();


### PR DESCRIPTION
The callback passed to API calls can return an instance of
`ServiceError`, a type from grpc-js. The type is mentioned in the
documentation and the tutorial, but wasn't re-exported in the SDK. This
has been fixed.