### PR TITLE
Fix publishing of Node SDK

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -35,7 +35,7 @@ jobs:
           cache-dependency-path: sdk/node/package-lock.json
 
       - name: Install Buf dependencies
-        run: npm install -g grpc_tools_node_protoc_plugin_ts grpc-tools
+        run: npm install -g grpc_tools_node_protoc_ts grpc-tools
 
       - name: Set up Buf
         uses: bufbuild/buf-setup-action@v1.4.0


### PR DESCRIPTION
Automatically publishing the Node SDK failed due to an error in the GitHub Action job. When trying to install the tools required to compile the Protocol Buffers, the wrong name was used for the TypeScript plugin. The name has been fixed, and publishing should work now.