### PR TITLE
Fix build warnings with tonic and Rust 1.63.0+

### DIFF
--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,3 +1,8 @@
+// tonic does not derive `Eq` for the gRPC message types, which causes a warning from Clippy. The
+// current suggestion is to explicitly allow the lint in the module that imports the protos.
+// Read more: https://github.com/hyperium/tonic/issues/1056
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 pub mod v1 {
     tonic::include_proto!("atc.v1");
 }


### PR DESCRIPTION
Rust 1.63.0 introduced a new lint that checks if `PartialEq` is derived without also deriving `Eq`. This causes warnings when building the game, since tonic does not derive `Eq` for the gRPC message types. The current recommendation is to explicitly allow the lint in the module that imports the Protocol Buffers.

Read more: https://github.com/hyperium/tonic/issues/1056