### PR TITLE
Remove usage of actions-rs

### DIFF
--- a/.github/workflows/release-itch.yml
+++ b/.github/workflows/release-itch.yml
@@ -27,19 +27,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
 
       - name: Build release artifact
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+        run: cargo build --release
 
       - name: Create distribution folder
         run: mkdir ./dist
@@ -79,10 +73,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
@@ -127,19 +118,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
 
       - name: Build release artifact
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+        run: cargo build --release
 
       - name: Create distribution folder
         run: mkdir ./dist

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -179,10 +179,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -40,21 +40,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: clippy
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
 
       - name: Run Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   style:
     name: Check style
@@ -65,27 +57,23 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   test:
     name: Run tests
     runs-on: ubuntu-latest
 
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
+
     steps:
       - name: Install system dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y \
+          apt-get update && apt-get install -y \
           libx11-dev \
           libasound2-dev \
           libudev-dev
@@ -102,19 +90,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@master
-        with:
-          args: --skip-clean
-          version: 0.20.0
+      - name: Generate code coverage
+        run: |
+          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -81,19 +81,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
 
       - name: Compile test-server
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p test-server
+        run: cargo build -p test-server
 
       - name: Upload test-server
         uses: actions/upload-artifact@v3
@@ -353,19 +347,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
 
       - name: Compile Rust example
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p auto-traffic-control-example
+        run: cargo build -p auto-traffic-control-example
 
       - name: Download test-server
         uses: actions/download-artifact@v3
@@ -380,10 +368,7 @@ jobs:
         run: bin/test-server &
 
       - name: Run Rust example
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p auto-traffic-control-example
+        run: cargo run -p auto-traffic-control-example
 
   typescript:
     name: Test TypeScript bot


### PR DESCRIPTION
The actions-rs project [^1] on GitHub has sadly been abandoned, and does not run on the latest version of GitHub Actions.

[^1]: https://github.com/actions-rs