### PR TITLE
Create command and event busses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,9 @@ checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 [[package]]
 name = "simulation"
 version = "0.4.0-dev"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "slab"

--- a/game/simulation/Cargo.toml
+++ b/game/simulation/Cargo.toml
@@ -12,3 +12,4 @@ repository.workspace = true
 publish = false
 
 [dependencies]
+tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread"] }

--- a/game/simulation/src/bus/channel.rs
+++ b/game/simulation/src/bus/channel.rs
@@ -1,0 +1,37 @@
+use tokio::sync::broadcast;
+pub use tokio::sync::broadcast::error::{RecvError, SendError, TryRecvError};
+
+use crate::bus::receiver::Receiver;
+use crate::bus::sender::Sender;
+
+pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>)
+where
+    T: Clone,
+{
+    let (sender, receiver) = broadcast::channel(buffer);
+    (Sender { sender }, Receiver { receiver })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn one_sender_to_two_receivers() {
+        let (tx, mut rx1) = channel::<usize>(16);
+        let mut rx2 = tx.subscribe();
+
+        tokio::spawn(async move {
+            assert_eq!(rx1.recv().await.unwrap(), 10);
+            assert_eq!(rx1.recv().await.unwrap(), 20);
+        });
+
+        tokio::spawn(async move {
+            assert_eq!(rx2.recv().await.unwrap(), 10);
+            assert_eq!(rx2.recv().await.unwrap(), 20);
+        });
+
+        tx.send(10).unwrap();
+        tx.send(20).unwrap();
+    }
+}

--- a/game/simulation/src/bus/command.rs
+++ b/game/simulation/src/bus/command.rs
@@ -1,0 +1,33 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Command {}
+
+impl Display for Command {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Command")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Command>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Command>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Command>();
+    }
+}

--- a/game/simulation/src/bus/event.rs
+++ b/game/simulation/src/bus/event.rs
@@ -1,0 +1,33 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Event {}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Event")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Event>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Event>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Event>();
+    }
+}

--- a/game/simulation/src/bus/mod.rs
+++ b/game/simulation/src/bus/mod.rs
@@ -1,0 +1,11 @@
+pub use self::channel::*;
+pub use self::command::*;
+pub use self::event::*;
+pub use self::receiver::*;
+pub use self::sender::*;
+
+mod channel;
+mod command;
+mod event;
+mod receiver;
+mod sender;

--- a/game/simulation/src/bus/receiver.rs
+++ b/game/simulation/src/bus/receiver.rs
@@ -1,0 +1,50 @@
+use std::fmt::{Display, Formatter};
+
+use crate::bus::{RecvError, TryRecvError};
+
+#[derive(Debug)]
+pub struct Receiver<T> {
+    pub(super) receiver: tokio::sync::broadcast::Receiver<T>,
+}
+
+impl<T> Receiver<T>
+where
+    T: Clone,
+{
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        self.receiver.try_recv()
+    }
+
+    pub async fn recv(&mut self) -> Result<T, RecvError> {
+        self.receiver.recv().await
+    }
+}
+
+impl<T> Display for Receiver<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Receiver")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Receiver<()>>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Receiver<()>>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Receiver<()>>();
+    }
+}

--- a/game/simulation/src/bus/sender.rs
+++ b/game/simulation/src/bus/sender.rs
@@ -1,0 +1,49 @@
+use std::fmt::{Display, Formatter};
+
+use crate::bus::{Receiver, SendError};
+
+#[derive(Clone, Debug)]
+pub struct Sender<T> {
+    pub(super) sender: tokio::sync::broadcast::Sender<T>,
+}
+
+impl<T> Sender<T> {
+    pub fn send(&self, value: T) -> Result<usize, SendError<T>> {
+        self.sender.send(value)
+    }
+
+    pub fn subscribe(&self) -> Receiver<T> {
+        Receiver {
+            receiver: self.sender.subscribe(),
+        }
+    }
+}
+
+impl<T> Display for Sender<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sender")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Sender<()>>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Sender<()>>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Sender<()>>();
+    }
+}

--- a/game/simulation/src/lib.rs
+++ b/game/simulation/src/lib.rs
@@ -12,3 +12,5 @@
 //! The simulation is not responsible for the API of the game, and can in fact be run without an API
 //! altogether (e.g. for testing). It communicates with the API through command and event busses,
 //! which are passed to the simulation as arguments.
+
+pub mod bus;


### PR DESCRIPTION
The foundation for the command and event busses has been laid. The busses are wrappers around tokio's multi-producer, multi-consumer broadcast channel. This allows every API service on one side and every entity game in the other side to communicate with each other.