### PR TITLE
Create simple state machine for simulation

### DIFF
--- a/game/simulation/src/lib.rs
+++ b/game/simulation/src/lib.rs
@@ -13,7 +13,73 @@
 //! altogether (e.g. for testing). It communicates with the API through command and event busses,
 //! which are passed to the simulation as arguments.
 
+use std::fmt::Display;
+
+use crate::state::{Ready, Running};
+
 pub mod bus;
 pub mod component;
+mod state;
 
 const TILE_SIZE: u32 = 64;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Simulation<S> {
+    state: S,
+}
+
+impl Simulation<Ready> {
+    pub fn new() -> Self {
+        Self {
+            state: Ready::new(),
+        }
+    }
+}
+
+impl<S> Display for Simulation<S>
+where
+    S: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.state)
+    }
+}
+
+impl From<Simulation<Ready>> for Simulation<Running> {
+    fn from(_simulation: Simulation<Ready>) -> Self {
+        Self {
+            state: Running::new(),
+        }
+    }
+}
+
+impl From<Simulation<Running>> for Simulation<Ready> {
+    fn from(_simulation: Simulation<Running>) -> Self {
+        Self {
+            state: Ready::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Simulation<Ready>>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Simulation<Ready>>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Simulation<Ready>>();
+    }
+}

--- a/game/simulation/src/state/mod.rs
+++ b/game/simulation/src/state/mod.rs
@@ -1,0 +1,5 @@
+pub use self::ready::*;
+pub use self::running::*;
+
+mod ready;
+mod running;

--- a/game/simulation/src/state/ready.rs
+++ b/game/simulation/src/state/ready.rs
@@ -1,0 +1,45 @@
+use std::fmt::Display;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Ready {}
+
+impl Ready {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Display for Ready {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ready")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let ready = Ready::new();
+        assert_eq!("ready", ready.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Ready>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Ready>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Ready>();
+    }
+}

--- a/game/simulation/src/state/running.rs
+++ b/game/simulation/src/state/running.rs
@@ -1,0 +1,45 @@
+use std::fmt::Display;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Running {}
+
+impl Running {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Display for Running {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "running")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let running = Running::new();
+        assert_eq!("running", running.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Running>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Running>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Running>();
+    }
+}


### PR DESCRIPTION
The simulation is modelled as a simple state machine with a `ready` and a `running` state. When the player starts a new game, the simulation switches from `ready` to `running` and runs the game. When the game ends, it goes back to `ready`.