### PR TITLE
Send events when game state changes

### DIFF
--- a/game/simulation/src/behavior/mod.rs
+++ b/game/simulation/src/behavior/mod.rs
@@ -1,0 +1,3 @@
+pub use self::observable::*;
+
+mod observable;

--- a/game/simulation/src/behavior/observable.rs
+++ b/game/simulation/src/behavior/observable.rs
@@ -1,0 +1,9 @@
+use crate::bus::{Event, SendError, Sender};
+
+pub trait Observable {
+    fn event_bus(&self) -> &Sender<Event>;
+
+    fn notify(&self, event: Event) -> Result<usize, SendError<Event>> {
+        self.event_bus().send(event)
+    }
+}

--- a/game/simulation/src/bus/event.rs
+++ b/game/simulation/src/bus/event.rs
@@ -1,7 +1,10 @@
 use std::fmt::{Display, Formatter};
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum Event {}
+pub enum Event {
+    GameStarted,
+    GameStopped,
+}
 
 impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
When the simulation transitions from the ready to running state or vice versa the corresponding event is now being sent via the event bus.