### PR TITLE
Start a game and transition to running state

### DIFF
--- a/game/simulation/src/behavior/mod.rs
+++ b/game/simulation/src/behavior/mod.rs
@@ -1,3 +1,5 @@
 pub use self::observable::*;
+pub use self::updateable::*;
 
 mod observable;
+mod updateable;

--- a/game/simulation/src/behavior/updateable.rs
+++ b/game/simulation/src/behavior/updateable.rs
@@ -1,0 +1,3 @@
+pub trait Updateable {
+    fn update(&mut self, delta: f32);
+}

--- a/game/simulation/src/bus/command.rs
+++ b/game/simulation/src/bus/command.rs
@@ -1,7 +1,9 @@
 use std::fmt::{Display, Formatter};
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum Command {}
+pub enum Command {
+    StartGame,
+}
 
 impl Display for Command {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/game/simulation/src/state/mod.rs
+++ b/game/simulation/src/state/mod.rs
@@ -9,7 +9,6 @@ mod ready;
 mod running;
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // TODO: Remove when changing states is implemented
 pub enum State {
     Ready(Ready),
     Running(Running),

--- a/game/simulation/src/state/ready.rs
+++ b/game/simulation/src/state/ready.rs
@@ -2,6 +2,7 @@ use crate::behavior::Observable;
 use std::fmt::Display;
 
 use crate::bus::{Event, Sender};
+use crate::state::Running;
 
 #[derive(Clone, Debug)]
 pub struct Ready {
@@ -23,6 +24,12 @@ impl Display for Ready {
 impl Observable for Ready {
     fn event_bus(&self) -> &Sender<Event> {
         &self.event_bus
+    }
+}
+
+impl From<&Running> for Ready {
+    fn from(state: &Running) -> Self {
+        Ready::new(state.event_bus().clone())
     }
 }
 

--- a/game/simulation/src/state/running.rs
+++ b/game/simulation/src/state/running.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use crate::behavior::Observable;
 use crate::bus::{Event, Sender};
+use crate::state::Ready;
 
 #[derive(Clone, Debug)]
 pub struct Running {
@@ -9,15 +10,27 @@ pub struct Running {
 }
 
 impl Running {
-    #[allow(dead_code)] // TODO: Remove when changing states is implemented
     pub fn new(event_bus: Sender<Event>) -> Self {
-        Self { event_bus }
+        let running = Self { event_bus };
+
+        // TODO: Handle error gracefully
+        running
+            .notify(Event::GameStarted)
+            .expect("failed to send GameStarted event");
+
+        running
     }
 }
 
 impl Display for Running {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "running")
+    }
+}
+
+impl From<&Ready> for Running {
+    fn from(state: &Ready) -> Self {
+        Self::new(state.event_bus().clone())
     }
 }
 
@@ -35,7 +48,7 @@ mod tests {
 
     #[test]
     fn trait_display() {
-        let (sender, _) = channel(256);
+        let (sender, _receiver) = channel(256);
         let running = Running::new(sender);
 
         assert_eq!("running", running.to_string());

--- a/game/simulation/tests/start_game.rs
+++ b/game/simulation/tests/start_game.rs
@@ -1,0 +1,22 @@
+use simulation::behavior::Updateable;
+use simulation::bus::{channel, Command, Event};
+use simulation::Simulation;
+
+#[tokio::test]
+async fn start_game() {
+    let (command_sender, command_receiver) = channel(1);
+    let (event_sender, mut event_receiver) = channel(1);
+
+    let mut simulation = Simulation::new(command_receiver, event_sender);
+
+    command_sender.send(Command::StartGame).unwrap();
+
+    simulation.update(0.0);
+
+    let event = event_receiver
+        .recv()
+        .await
+        .expect("failed to receive event");
+
+    assert_eq!(Event::GameStarted, event);
+}


### PR DESCRIPTION
The `StartGame` command has been implemented and hooked up to the simulation. When the simulation is ready, i.e. no game is currently running, the simulation transitions into the running state and starts a new game. This triggers the `GameStarted` event.