### PR TITLE
Create entity for airports

### DIFF
--- a/game/simulation/src/entity/airport.rs
+++ b/game/simulation/src/entity/airport.rs
@@ -1,0 +1,44 @@
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+use crate::map::Node;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Airport {
+    node: Arc<Node>,
+}
+
+impl Airport {
+    pub fn new(node: Arc<Node>) -> Self {
+        Self { node }
+    }
+}
+
+impl Display for Airport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Airport")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Airport>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Airport>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Airport>();
+    }
+}

--- a/game/simulation/src/entity/mod.rs
+++ b/game/simulation/src/entity/mod.rs
@@ -1,0 +1,3 @@
+pub use self::airport::*;
+
+mod airport;

--- a/game/simulation/src/lib.rs
+++ b/game/simulation/src/lib.rs
@@ -22,6 +22,7 @@ use crate::state::State;
 pub mod behavior;
 pub mod bus;
 
+mod entity;
 mod map;
 mod state;
 

--- a/game/simulation/src/map/loader.rs
+++ b/game/simulation/src/map/loader.rs
@@ -1,4 +1,6 @@
+use crate::entity::Airport;
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use crate::map::{Map, Node};
 
@@ -18,6 +20,7 @@ impl MapLoader {
     }
 
     fn parse(name: String, map: &str) -> Map {
+        let mut airports = Vec::new();
         let mut nodes = Vec::new();
 
         let mut width = 0;
@@ -34,9 +37,23 @@ impl MapLoader {
 
             for (y, tile) in line.chars().enumerate() {
                 let node = match tile {
-                    '#' => Node::restricted(x as u32, y as u32),
-                    _ => Node::unrestricted(x as u32, y as u32),
+                    '#' => Node {
+                        longitude: x as u32,
+                        latitude: y as u32,
+                        restricted: true,
+                    },
+                    _ => Node {
+                        longitude: x as u32,
+                        latitude: y as u32,
+                        restricted: false,
+                    },
                 };
+                let node = Arc::new(node);
+
+                if tile == 'A' {
+                    let airport = Airport::new(node.clone());
+                    airports.push(airport);
+                }
 
                 nodes.push(node);
             }
@@ -48,8 +65,11 @@ impl MapLoader {
 
         Map {
             name,
+
             width: width as u32,
             height: height as u32,
+
+            airports,
             grid: nodes,
         }
     }

--- a/game/simulation/src/map/location.rs
+++ b/game/simulation/src/map/location.rs
@@ -43,7 +43,11 @@ mod tests {
 
     #[test]
     fn trait_from_node_zero() {
-        let node = Node::unrestricted(0, 0);
+        let node = Node {
+            longitude: 0,
+            latitude: 0,
+            restricted: false,
+        };
 
         let location = Location::from(&node);
 
@@ -52,7 +56,11 @@ mod tests {
 
     #[test]
     fn trait_from_node_nonzero() {
-        let node = Node::unrestricted(1, 2);
+        let node = Node {
+            longitude: 1,
+            latitude: 2,
+            restricted: false,
+        };
 
         let location = Location::from(&node);
 

--- a/game/simulation/src/map/mod.rs
+++ b/game/simulation/src/map/mod.rs
@@ -1,7 +1,10 @@
+use crate::entity::Airport;
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
 pub use self::loader::*;
 pub use self::location::*;
 pub use self::node::*;
-use std::fmt::{Display, Formatter};
 
 mod loader;
 mod location;
@@ -14,7 +17,8 @@ pub struct Map {
     width: u32,
     height: u32,
 
-    grid: Vec<Node>,
+    airports: Vec<Airport>,
+    grid: Vec<Arc<Node>>,
 }
 
 impl Map {

--- a/game/simulation/src/map/node.rs
+++ b/game/simulation/src/map/node.rs
@@ -2,28 +2,12 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Node {
-    longitude: u32,
-    latitude: u32,
-    restricted: bool,
+    pub(super) longitude: u32,
+    pub(super) latitude: u32,
+    pub(super) restricted: bool,
 }
 
 impl Node {
-    pub fn restricted(longitude: u32, latitude: u32) -> Self {
-        Self {
-            longitude,
-            latitude,
-            restricted: true,
-        }
-    }
-
-    pub fn unrestricted(longitude: u32, latitude: u32) -> Self {
-        Self {
-            longitude,
-            latitude,
-            restricted: false,
-        }
-    }
-
     pub fn longitude(&self) -> u32 {
         self.longitude
     }


### PR DESCRIPTION
A new struct has been added that represents an airport. For now, airports only store a reference to their node in the routing grid. Later commits will add a tag as well so that they are color-coded.