### PR TITLE
Create entity for airplanes

### DIFF
--- a/game/simulation/src/bus/event.rs
+++ b/game/simulation/src/bus/event.rs
@@ -1,9 +1,11 @@
 use std::fmt::{Display, Formatter};
 
-use crate::map::Map;
+use crate::component::{AirplaneId, FlightPlan, Tag};
+use crate::map::{Location, Map};
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Event {
+    AirplaneDetected(AirplaneId, Location, FlightPlan, Tag),
     GameStarted(Map),
     GameStopped,
 }

--- a/game/simulation/src/component.rs
+++ b/game/simulation/src/component.rs
@@ -1,3 +1,0 @@
-pub use self::tag::*;
-
-mod tag;

--- a/game/simulation/src/component/airplane_id.rs
+++ b/game/simulation/src/component/airplane_id.rs
@@ -1,0 +1,61 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct AirplaneId(String);
+
+impl AirplaneId {
+    pub fn new(id: String) -> Self {
+        Self(id)
+    }
+
+    pub fn get(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for AirplaneId {
+    fn default() -> Self {
+        Self::new("AT-0000".to_string())
+    }
+}
+
+impl Display for AirplaneId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get() {
+        let id = AirplaneId::new("test".to_string());
+        assert_eq!(id.get(), "test");
+    }
+
+    #[test]
+    fn trait_display() {
+        let id = AirplaneId::new("test".to_string());
+        assert_eq!(format!("{}", id), "test");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AirplaneId>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AirplaneId>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<AirplaneId>();
+    }
+}

--- a/game/simulation/src/component/flight_plan.rs
+++ b/game/simulation/src/component/flight_plan.rs
@@ -1,0 +1,47 @@
+use std::fmt::{Display, Formatter};
+
+use crate::map::Node;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct FlightPlan(Vec<Node>);
+
+impl FlightPlan {
+    pub fn new(flight_plan: Vec<Node>) -> Self {
+        Self(flight_plan)
+    }
+}
+
+impl Display for FlightPlan {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FlightPlan")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let flight_plan = FlightPlan::default();
+        assert_eq!("FlightPlan", flight_plan.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<FlightPlan>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<FlightPlan>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<FlightPlan>();
+    }
+}

--- a/game/simulation/src/component/mod.rs
+++ b/game/simulation/src/component/mod.rs
@@ -1,0 +1,7 @@
+pub use self::airplane_id::*;
+pub use self::flight_plan::*;
+pub use self::tag::*;
+
+mod airplane_id;
+mod flight_plan;
+mod tag;

--- a/game/simulation/src/entity/airplane.rs
+++ b/game/simulation/src/entity/airplane.rs
@@ -1,0 +1,94 @@
+use crate::behavior::Observable;
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+use crate::bus::{Event, Sender};
+use crate::component::{AirplaneId, FlightPlan, Tag};
+use crate::map::{Location, Node};
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // TODO: Remove when path finding is implemented
+pub struct Airplane {
+    event_bus: Sender<Event>,
+
+    id: AirplaneId,
+    location: Location,
+    flight_plan: FlightPlan,
+    travelled_route: Vec<Arc<Node>>,
+    tag: Tag,
+}
+
+impl Airplane {
+    #[allow(dead_code)] // TODO: Remove when airplanes get spawned
+    pub fn new(event_bus: Sender<Event>, id: AirplaneId, tag: Tag, start: Arc<Node>) -> Self {
+        let airplane = Self {
+            event_bus,
+            id,
+            location: (&start).into(),
+            flight_plan: FlightPlan::default(),
+            travelled_route: vec![start],
+            tag,
+        };
+
+        airplane
+            .notify(Event::AirplaneDetected(
+                airplane.id.clone(),
+                airplane.location,
+                airplane.flight_plan.clone(),
+                airplane.tag,
+            ))
+            .expect("failed to send AirplaneDetected event");
+
+        airplane
+    }
+}
+
+impl Display for Airplane {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Airplane {}", self.id)
+    }
+}
+
+impl Observable for Airplane {
+    fn event_bus(&self) -> &Sender<Event> {
+        &self.event_bus
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus::channel;
+
+    #[test]
+    fn trait_display() {
+        let (sender, _receiver) = channel(1);
+
+        let airplane = Airplane::new(
+            sender,
+            AirplaneId::default(),
+            Tag::Blue,
+            Arc::new(Node::default()),
+        );
+
+        assert_eq!("Airplane AT-0000", airplane.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Airplane>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Airplane>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Airplane>();
+    }
+}

--- a/game/simulation/src/entity/mod.rs
+++ b/game/simulation/src/entity/mod.rs
@@ -1,3 +1,5 @@
+pub use self::airplane::*;
 pub use self::airport::*;
 
+mod airplane;
 mod airport;

--- a/game/simulation/src/map/location.rs
+++ b/game/simulation/src/map/location.rs
@@ -1,4 +1,6 @@
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
+use std::sync::Arc;
 
 use geo::Point;
 
@@ -34,6 +36,12 @@ impl From<&Node> for Location {
         let y = node.latitude() * TILE_SIZE;
 
         Self::new(x as f64, y as f64)
+    }
+}
+
+impl From<&Arc<Node>> for Location {
+    fn from(node: &Arc<Node>) -> Self {
+        node.deref().into()
     }
 }
 

--- a/game/simulation/src/state/running.rs
+++ b/game/simulation/src/state/running.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use crate::behavior::Observable;
 use crate::bus::{Event, Sender};
+use crate::entity::Airplane;
 use crate::map::{Map, MapLoader, Maps};
 use crate::state::Ready;
 
@@ -9,6 +10,8 @@ use crate::state::Ready;
 #[allow(dead_code)] // TODO: Remove when map is used
 pub struct Running {
     event_bus: Sender<Event>,
+
+    airplanes: Vec<Airplane>,
     map: Map,
 }
 
@@ -18,6 +21,7 @@ impl Running {
 
         let running = Self {
             event_bus,
+            airplanes: Vec::new(),
             map: map.clone(),
         };
 


### PR DESCRIPTION
A new struct has been created for airplanes. Airplanes have a unique id, a location, a flight plan, a list of past nodes they traversed, and a tag. Airplanes send an event when they are spawned, and will later broadcast their location whenever they move.