### PR TITLE
Spawn airplanes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +850,9 @@ name = "simulation"
 version = "0.4.0-dev"
 dependencies = [
  "geo",
+ "parking_lot",
+ "rand",
+ "time",
  "tokio",
 ]
 
@@ -911,6 +937,22 @@ dependencies = [
  "tokio",
  "tonic",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+dependencies = [
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "tokio"

--- a/game/simulation/Cargo.toml
+++ b/game/simulation/Cargo.toml
@@ -13,4 +13,7 @@ publish = false
 
 [dependencies]
 geo = "0.23"
+parking_lot = "0.12"
+rand = "0.8"
+time = "0.3"
 tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread"] }

--- a/game/simulation/src/bus/event.rs
+++ b/game/simulation/src/bus/event.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use crate::component::{AirplaneId, FlightPlan, Tag};
 use crate::map::{Location, Map};
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug)]
 pub enum Event {
     AirplaneDetected(AirplaneId, Location, FlightPlan, Tag),
     GameStarted(Map),

--- a/game/simulation/src/component/flight_plan.rs
+++ b/game/simulation/src/component/flight_plan.rs
@@ -1,12 +1,13 @@
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use crate::map::Node;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct FlightPlan(Vec<Node>);
+pub struct FlightPlan(Vec<Arc<Node>>);
 
 impl FlightPlan {
-    pub fn new(flight_plan: Vec<Node>) -> Self {
+    pub fn new(flight_plan: Vec<Arc<Node>>) -> Self {
         Self(flight_plan)
     }
 }

--- a/game/simulation/src/entity/airplane.rs
+++ b/game/simulation/src/entity/airplane.rs
@@ -19,14 +19,19 @@ pub struct Airplane {
 }
 
 impl Airplane {
-    #[allow(dead_code)] // TODO: Remove when airplanes get spawned
-    pub fn new(event_bus: Sender<Event>, id: AirplaneId, tag: Tag, start: Arc<Node>) -> Self {
+    pub fn new(
+        event_bus: Sender<Event>,
+        id: AirplaneId,
+        tag: Tag,
+        start_node: Arc<Node>,
+        first_node: Arc<Node>,
+    ) -> Self {
         let airplane = Self {
             event_bus,
             id,
-            location: (&start).into(),
-            flight_plan: FlightPlan::default(),
-            travelled_route: vec![start],
+            location: (&start_node).into(),
+            flight_plan: FlightPlan::new(vec![first_node]),
+            travelled_route: vec![start_node],
             tag,
         };
 
@@ -68,6 +73,7 @@ mod tests {
             sender,
             AirplaneId::default(),
             Tag::Blue,
+            Arc::new(Node::default()),
             Arc::new(Node::default()),
         );
 

--- a/game/simulation/src/entity/mod.rs
+++ b/game/simulation/src/entity/mod.rs
@@ -1,5 +1,7 @@
 pub use self::airplane::*;
 pub use self::airport::*;
+pub use self::spawner::*;
 
 mod airplane;
 mod airport;
+mod spawner;

--- a/game/simulation/src/entity/spawner.rs
+++ b/game/simulation/src/entity/spawner.rs
@@ -1,0 +1,162 @@
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+use rand::prelude::*;
+use time::{Duration, Instant};
+
+use crate::behavior::Updateable;
+use crate::bus::{Event, Sender};
+use crate::component::Tag;
+use crate::entity::Airplane;
+use crate::map::{Map, Node, MAP_BORDER_WIDTH};
+use crate::util::AirplaneIdGenerator;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum Side {
+    North,
+    East,
+    South,
+    West,
+}
+
+impl Side {
+    fn random(rng: &mut ThreadRng) -> Self {
+        match rng.gen_range(0..=3) {
+            0 => Self::North,
+            1 => Self::East,
+            2 => Self::South,
+            _ => Self::West,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Debug, Default)]
+struct Spawn {
+    start_node: Arc<Node>,
+    first_node: Arc<Node>,
+}
+
+#[derive(Debug)]
+pub struct Spawner {
+    event_bus: Sender<Event>,
+    rng: ThreadRng,
+
+    airplane_id_generator: AirplaneIdGenerator,
+    map: Arc<Mutex<Map>>,
+    width: u32,
+    height: u32,
+
+    interval: Duration,
+    last_spawn: Instant,
+}
+
+impl Spawner {
+    pub fn new(event_bus: Sender<Event>, map: Arc<Mutex<Map>>, interval: Duration) -> Self {
+        let width = map.lock().width();
+        let height = map.lock().height();
+
+        Self {
+            event_bus,
+            rng: thread_rng(),
+
+            airplane_id_generator: AirplaneIdGenerator::default(),
+            map,
+            width,
+            height,
+
+            interval,
+            last_spawn: Instant::now(),
+        }
+    }
+
+    fn random_spawn(&mut self) -> Spawn {
+        let side = Side::random(&mut self.rng);
+
+        let start_node = self.start_node(side);
+        let first_node = self.first_node(side, &start_node);
+
+        Spawn {
+            start_node,
+            first_node,
+        }
+    }
+
+    fn start_node(&mut self, side: Side) -> Arc<Node> {
+        let (x, y) = match side {
+            Side::North => (
+                self.rng
+                    .gen_range(MAP_BORDER_WIDTH..(self.width - MAP_BORDER_WIDTH)),
+                0,
+            ),
+            Side::East => (
+                self.width - 1,
+                self.rng
+                    .gen_range(MAP_BORDER_WIDTH..(self.height - MAP_BORDER_WIDTH)),
+            ),
+            Side::South => (
+                self.rng
+                    .gen_range(MAP_BORDER_WIDTH..(self.width - MAP_BORDER_WIDTH)),
+                self.height - 1,
+            ),
+            Side::West => (
+                0,
+                self.rng
+                    .gen_range(MAP_BORDER_WIDTH..(self.height - MAP_BORDER_WIDTH)),
+            ),
+        };
+
+        self.map
+            .lock()
+            .grid()
+            .get(x, y)
+            .expect("failed to get start node for airplane")
+            .clone()
+    }
+
+    fn first_node(&self, side: Side, start_node: &Arc<Node>) -> Arc<Node> {
+        let x = start_node.longitude();
+        let y = start_node.latitude();
+
+        let (x, y) = match side {
+            Side::North => (x, y + MAP_BORDER_WIDTH),
+            Side::East => (x - MAP_BORDER_WIDTH, y),
+            Side::South => (x, y - MAP_BORDER_WIDTH),
+            Side::West => (x + MAP_BORDER_WIDTH, y),
+        };
+
+        self.map
+            .lock()
+            .grid()
+            .get(x, y)
+            .expect("failed to get first node for flight plan")
+            .clone()
+    }
+
+    fn random_tag(&mut self) -> Tag {
+        let tag = self.rng.gen_bool(0.5);
+
+        if tag {
+            Tag::Blue
+        } else {
+            Tag::Red
+        }
+    }
+}
+
+impl Updateable for Spawner {
+    fn update(&mut self, _delta: f32) {
+        if self.last_spawn + self.interval < Instant::now() {
+            let spawn = self.random_spawn();
+
+            let airplane = Airplane::new(
+                self.event_bus.clone(),
+                self.airplane_id_generator.generate(),
+                self.random_tag(),
+                spawn.start_node,
+                spawn.first_node,
+            );
+
+            self.map.lock().airplanes_mut().push(airplane);
+        }
+    }
+}

--- a/game/simulation/src/lib.rs
+++ b/game/simulation/src/lib.rs
@@ -26,6 +26,7 @@ mod component;
 mod entity;
 mod map;
 mod state;
+mod util;
 
 const TILE_SIZE: u32 = 64;
 
@@ -88,18 +89,6 @@ mod tests {
         let simulation = Simulation::new(command_receiver, event_sender);
 
         assert_eq!("game ready", simulation.to_string());
-    }
-
-    #[test]
-    fn trait_send() {
-        fn assert_send<T: Send>() {}
-        assert_send::<Simulation>();
-    }
-
-    #[test]
-    fn trait_sync() {
-        fn assert_sync<T: Sync>() {}
-        assert_sync::<Simulation>();
     }
 
     #[test]

--- a/game/simulation/src/map/grid.rs
+++ b/game/simulation/src/map/grid.rs
@@ -1,0 +1,71 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Grid<T> {
+    width: u32,
+    height: u32,
+
+    elements: Vec<T>,
+}
+
+impl<T> Grid<T> {
+    pub fn new(width: u32, height: u32, elements: Vec<T>) -> Self {
+        Self {
+            width,
+            height,
+            elements,
+        }
+    }
+
+    pub fn get(&self, x: u32, y: u32) -> Option<&T> {
+        self.elements.get((y * self.width + x) as usize)
+    }
+}
+
+impl<T> Display for Grid<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Grid")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_element() {
+        let grid = Grid::new(2, 2, vec![1, 2, 3, 4]);
+
+        assert_eq!(grid.get(0, 0), Some(&1));
+        assert_eq!(grid.get(1, 0), Some(&2));
+        assert_eq!(grid.get(0, 1), Some(&3));
+        assert_eq!(grid.get(1, 1), Some(&4));
+    }
+
+    #[test]
+    fn get_element_out_of_bounds() {
+        let grid = Grid::new(2, 2, vec![1, 2]);
+
+        assert_eq!(grid.get(2, 0), None);
+        assert_eq!(grid.get(0, 2), None);
+        assert_eq!(grid.get(2, 2), None);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Grid<u32>>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Grid<u32>>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Grid<u32>>();
+    }
+}

--- a/game/simulation/src/map/loader.rs
+++ b/game/simulation/src/map/loader.rs
@@ -1,9 +1,9 @@
-use crate::component::Tag;
-use crate::entity::Airport;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
-use crate::map::{Map, Node};
+use crate::component::Tag;
+use crate::entity::Airport;
+use crate::map::{Grid, Map, Node};
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum Maps {
@@ -79,7 +79,8 @@ impl MapLoader {
             height: height as u32,
 
             airports,
-            grid: nodes,
+            airplanes: Vec::new(),
+            grid: Grid::new(width as u32, height as u32, nodes),
         }
     }
 }

--- a/game/simulation/src/map/mod.rs
+++ b/game/simulation/src/map/mod.rs
@@ -1,16 +1,21 @@
-use crate::entity::Airport;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+use crate::entity::{Airplane, Airport};
+
+pub use self::grid::*;
 pub use self::loader::*;
 pub use self::location::*;
 pub use self::node::*;
 
+mod grid;
 mod loader;
 mod location;
 mod node;
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub const MAP_BORDER_WIDTH: u32 = 3;
+
+#[derive(Clone, Debug, Default)]
 pub struct Map {
     name: String,
 
@@ -18,7 +23,8 @@ pub struct Map {
     height: u32,
 
     airports: Vec<Airport>,
-    grid: Vec<Arc<Node>>,
+    airplanes: Vec<Airplane>,
+    grid: Grid<Arc<Node>>,
 }
 
 impl Map {
@@ -28,6 +34,22 @@ impl Map {
 
     pub fn height(&self) -> u32 {
         self.height
+    }
+
+    pub fn airports(&self) -> &[Airport] {
+        &self.airports
+    }
+
+    pub fn airplanes(&self) -> &[Airplane] {
+        &self.airplanes
+    }
+
+    pub fn airplanes_mut(&mut self) -> &mut Vec<Airplane> {
+        &mut self.airplanes
+    }
+
+    pub fn grid(&self) -> &Grid<Arc<Node>> {
+        &self.grid
     }
 }
 

--- a/game/simulation/src/state/mod.rs
+++ b/game/simulation/src/state/mod.rs
@@ -8,7 +8,7 @@ pub use self::running::*;
 mod ready;
 mod running;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum State {
     Ready(Ready),
     Running(Running),
@@ -41,18 +41,6 @@ mod tests {
         let game = State::new(sender);
 
         assert_eq!("game ready", game.to_string());
-    }
-
-    #[test]
-    fn trait_send() {
-        fn assert_send<T: Send>() {}
-        assert_send::<State>();
-    }
-
-    #[test]
-    fn trait_sync() {
-        fn assert_sync<T: Sync>() {}
-        assert_sync::<State>();
     }
 
     #[test]

--- a/game/simulation/src/util/airplane_id_generator.rs
+++ b/game/simulation/src/util/airplane_id_generator.rs
@@ -1,0 +1,64 @@
+use std::fmt::Display;
+
+use crate::component::AirplaneId;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct AirplaneIdGenerator {
+    last_id: u32,
+}
+
+impl AirplaneIdGenerator {
+    pub fn generate(&mut self) -> AirplaneId {
+        self.last_id += 1;
+
+        AirplaneId::new(format!("AT-{:0width$}", self.last_id, width = 4))
+    }
+}
+
+impl Display for AirplaneIdGenerator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AirplaneIdGenerator {{ last_id: {} }}", self.last_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate() {
+        let mut generator = AirplaneIdGenerator::default();
+
+        let id = generator.generate();
+
+        assert_eq!(id.get(), "AT-0001");
+    }
+
+    #[test]
+    fn trait_display() {
+        let generator = AirplaneIdGenerator::default();
+
+        assert_eq!(
+            format!("{}", generator),
+            "AirplaneIdGenerator { last_id: 0 }"
+        );
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AirplaneIdGenerator>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AirplaneIdGenerator>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<AirplaneIdGenerator>();
+    }
+}

--- a/game/simulation/src/util/mod.rs
+++ b/game/simulation/src/util/mod.rs
@@ -1,0 +1,3 @@
+pub use self::airplane_id_generator::*;
+
+mod airplane_id_generator;


### PR DESCRIPTION
Airplanes are spawned on a two second timer along the edge of the map. The implementation makes heavy uses of reference counters to ensure that the map, airplane spawner, and the airplanes themselves use the same nodes in the routing grid. While this is not strictly necessary at this time, it is an important requirement for more dynamic maps in the future (e.g. nodes that change their restriction status while playing).