### PR TITLE
Refactor command and event busses

### DIFF
--- a/game/simulation/src/behavior/commandable.rs
+++ b/game/simulation/src/behavior/commandable.rs
@@ -1,0 +1,9 @@
+use crate::bus::{Event, SendError, Sender};
+
+pub trait Observable {
+    fn event_bus(&self) -> &Sender<Event>;
+
+    fn notify(&self, event: Event) -> Result<usize, SendError<Event>> {
+        self.event_bus().send(event)
+    }
+}


### PR DESCRIPTION
The two busses for commands and events have been refactored. Specifically, they are no longer passed as arguments through the object hierarchy. Instead, a constant that can be accessed from any location in the code base is used.