### PR TITLE
Despawn airplanes

### DIFF
--- a/game/simulation/src/bus/event.rs
+++ b/game/simulation/src/bus/event.rs
@@ -7,6 +7,9 @@ use crate::map::{Airport, Grid, Location, Node};
 #[derive(Clone, Debug)]
 pub enum Event {
     AirplaneDetected(AirplaneId, Location, FlightPlan, Tag),
+    AirplaneLanded(AirplaneId),
+    FlightPlanUpdated(AirplaneId, FlightPlan),
+    LandingAborted(AirplaneId),
     GameStarted(Vec<Airport>, Grid<Arc<Node>>, u32, u32),
     GameStopped,
 }

--- a/game/simulation/src/map/airport.rs
+++ b/game/simulation/src/map/airport.rs
@@ -2,17 +2,36 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 use crate::component::Tag;
-use crate::map::Node;
+use crate::map::{Location, Node};
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Airport {
     node: Arc<Node>,
+    location: Location,
     tag: Tag,
 }
 
 impl Airport {
     pub fn new(node: Arc<Node>, tag: Tag) -> Self {
-        Self { node, tag }
+        let location = (&node).into();
+
+        Self {
+            node,
+            location,
+            tag,
+        }
+    }
+
+    pub fn node(&self) -> &Arc<Node> {
+        &self.node
+    }
+
+    pub fn location(&self) -> &Location {
+        &self.location
+    }
+
+    pub fn tag(&self) -> Tag {
+        self.tag
     }
 }
 

--- a/game/simulation/src/map/direction.rs
+++ b/game/simulation/src/map/direction.rs
@@ -1,0 +1,49 @@
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Direction {
+    North,
+    NorthEast,
+    East,
+    SouthEast,
+    South,
+    SouthWest,
+    West,
+    NorthWest,
+}
+
+impl Direction {
+    pub fn as_tuple(&self) -> (i32, i32) {
+        match self {
+            Self::North => (0, -1),
+            Self::NorthEast => (-1, -1),
+            Self::East => (-1, 0),
+            Self::SouthEast => (-1, 1),
+            Self::South => (0, 1),
+            Self::SouthWest => (1, 1),
+            Self::West => (1, 0),
+            Self::NorthWest => (1, -1),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Direction>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Direction>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Direction>();
+    }
+}

--- a/game/simulation/src/map/grid.rs
+++ b/game/simulation/src/map/grid.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
@@ -19,6 +20,33 @@ impl<T> Grid<T> {
 
     pub fn get(&self, x: u32, y: u32) -> Option<&T> {
         self.elements.get((y * self.width + x) as usize)
+    }
+}
+
+impl<T> Grid<T>
+where
+    T: Clone,
+{
+    pub fn neighbors(&self, x: u32, y: u32) -> Vec<T> {
+        let width_range = x.saturating_sub(1)..=min(self.width.saturating_sub(1), x + 1);
+        let height_range = y.saturating_sub(1)..=min(self.height.saturating_sub(1), y + 1);
+
+        let mut neighbors = Vec::new();
+
+        for inner_y in height_range {
+            // TODO: Refactor to avoid clone
+            for inner_x in width_range.clone() {
+                if inner_x == x && inner_y == y {
+                    continue;
+                }
+
+                if let Some(node) = self.get(inner_x, inner_y) {
+                    neighbors.push(node.clone());
+                }
+            }
+        }
+
+        neighbors
     }
 }
 
@@ -49,6 +77,42 @@ mod tests {
         assert_eq!(grid.get(2, 0), None);
         assert_eq!(grid.get(0, 2), None);
         assert_eq!(grid.get(2, 2), None);
+    }
+
+    #[test]
+    fn neighbors_without_neighbors() {
+        let grid = Grid::new(1, 1, vec![1]);
+
+        let neighbors = grid.neighbors(0, 0);
+
+        assert!(neighbors.is_empty());
+    }
+
+    #[test]
+    fn neighbors_center() {
+        let grid = Grid::new(3, 3, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        let neighbors = grid.neighbors(1, 1);
+
+        assert_eq!(vec![1, 2, 3, 4, 6, 7, 8, 9], neighbors);
+    }
+
+    #[test]
+    fn neighbors_top_left() {
+        let grid = Grid::new(3, 3, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        let neighbors = grid.neighbors(0, 0);
+
+        assert_eq!(vec![2, 4, 5], neighbors);
+    }
+
+    #[test]
+    fn neighbors_edge() {
+        let grid = Grid::new(3, 3, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        let neighbors = grid.neighbors(0, 1);
+
+        assert_eq!(vec![1, 2, 5, 7, 8], neighbors);
     }
 
     #[test]

--- a/game/simulation/src/map/mod.rs
+++ b/game/simulation/src/map/mod.rs
@@ -2,12 +2,14 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 pub use self::airport::*;
+pub use self::direction::*;
 pub use self::grid::*;
 pub use self::loader::*;
 pub use self::location::*;
 pub use self::node::*;
 
 mod airport;
+mod direction;
 mod grid;
 mod loader;
 mod location;

--- a/game/simulation/src/map/node.rs
+++ b/game/simulation/src/map/node.rs
@@ -1,4 +1,6 @@
+use crate::map::Direction;
 use std::fmt::{Display, Formatter};
+use std::ops;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Node {
@@ -36,9 +38,179 @@ impl Display for Node {
     }
 }
 
+impl ops::Sub for &Node {
+    type Output = Direction;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let x = self.longitude() as i32 - rhs.longitude() as i32;
+        let y = self.latitude() as i32 - rhs.latitude() as i32;
+
+        if x == 0 {
+            if y <= 0 {
+                return Direction::South;
+            }
+            if y > 0 {
+                return Direction::North;
+            }
+        }
+        if x < 0 {
+            if y == 0 {
+                return Direction::East;
+            }
+            if y < 0 {
+                return Direction::SouthEast;
+            }
+            if y > 0 {
+                return Direction::NorthEast;
+            }
+        }
+        if x > 0 {
+            if y == 0 {
+                return Direction::West;
+            }
+            if y < 0 {
+                return Direction::SouthWest;
+            }
+            if y > 0 {
+                return Direction::NorthWest;
+            }
+        }
+
+        panic!("failed to determine direction");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sub_north() {
+        let node1 = Node {
+            longitude: 0,
+            latitude: 1,
+            restricted: false,
+        };
+        let node2 = Node {
+            longitude: 0,
+            latitude: 0,
+            restricted: false,
+        };
+
+        assert_eq!(Direction::North, &node1 - &node2);
+    }
+
+    #[test]
+    fn sub_north_east() {
+        let node1 = Node {
+            longitude: 0,
+            latitude: 1,
+            restricted: false,
+        };
+        let node2 = Node {
+            longitude: 1,
+            latitude: 0,
+            restricted: false,
+        };
+
+        assert_eq!(Direction::NorthEast, &node1 - &node2);
+    }
+
+    #[test]
+    fn sub_east() {
+        let node1 = Node {
+            longitude: 0,
+            latitude: 0,
+            restricted: false,
+        };
+        let node2 = Node {
+            longitude: 1,
+            latitude: 0,
+            restricted: false,
+        };
+
+        assert_eq!(Direction::East, &node1 - &node2);
+    }
+
+    #[test]
+    fn sub_south_east() {
+        let node1 = Node {
+            longitude: 0,
+            latitude: 0,
+            restricted: false,
+        };
+        let node2 = Node {
+            longitude: 1,
+            latitude: 1,
+            restricted: false,
+        };
+
+        assert_eq!(Direction::SouthEast, &node1 - &node2);
+    }
+
+    #[test]
+    fn sub_south() {
+        let node1 = Node {
+            longitude: 0,
+            latitude: 0,
+            restricted: false,
+        };
+        let node2 = Node {
+            longitude: 0,
+            latitude: 1,
+            restricted: false,
+        };
+
+        assert_eq!(Direction::South, &node1 - &node2);
+    }
+
+    #[test]
+    fn sub_south_west() {
+        let node1 = Node {
+            longitude: 1,
+            latitude: 0,
+            restricted: false,
+        };
+        let node2 = Node {
+            longitude: 0,
+            latitude: 1,
+            restricted: false,
+        };
+
+        assert_eq!(Direction::SouthWest, &node1 - &node2);
+    }
+
+    #[test]
+    fn sub_west() {
+        let node1 = Node {
+            longitude: 1,
+            latitude: 0,
+            restricted: false,
+        };
+        let node2 = Node {
+            longitude: 0,
+            latitude: 0,
+            restricted: false,
+        };
+
+        assert_eq!(Direction::West, &node1 - &node2);
+    }
+
+    #[test]
+    fn sub_north_west() {
+        let node1 = Node {
+            longitude: 1,
+            latitude: 1,
+            restricted: false,
+        };
+        let node2 = Node {
+            longitude: 0,
+            latitude: 0,
+            restricted: false,
+        };
+
+        assert_eq!(Direction::NorthWest, &node1 - &node2);
+    }
 
     #[test]
     fn trait_display() {

--- a/game/simulation/src/state/running.rs
+++ b/game/simulation/src/state/running.rs
@@ -9,7 +9,7 @@ use crate::behavior::{Commandable, Observable, Updateable};
 use crate::bus::{Command, Event, Receiver, Sender, COMMAND_BUS, EVENT_BUS};
 use crate::map::{MapLoader, Maps};
 use crate::state::Ready;
-use crate::system::{SpawnAirplaneSystem, System};
+use crate::system::{DespawnAirplaneSystem, SpawnAirplaneSystem, System};
 
 pub struct Running {
     command_bus: Receiver<Command>,
@@ -29,11 +29,14 @@ impl Running {
 
         let map = Arc::new(Mutex::new(map));
 
-        let systems: Vec<Box<dyn System>> = vec![Box::new(SpawnAirplaneSystem::new(
-            EVENT_BUS.0.clone(),
-            map,
-            Duration::seconds(2),
-        ))];
+        let systems: Vec<Box<dyn System>> = vec![
+            Box::new(DespawnAirplaneSystem::new(EVENT_BUS.0.clone(), map.clone())),
+            Box::new(SpawnAirplaneSystem::new(
+                EVENT_BUS.0.clone(),
+                map,
+                Duration::seconds(2),
+            )),
+        ];
 
         let running = Self {
             command_bus: COMMAND_BUS.1.resubscribe(),

--- a/game/simulation/src/system/despawn_airplane.rs
+++ b/game/simulation/src/system/despawn_airplane.rs
@@ -1,0 +1,104 @@
+use hecs::World;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::bus::{Event, Sender};
+use crate::component::{AirplaneId, FlightPlan, Tag};
+use crate::map::{Airport, Grid, Location, Map, Node};
+use crate::system::System;
+
+#[derive(Clone, Debug)]
+pub struct DespawnAirplaneSystem {
+    event_bus: Sender<Event>,
+    map: Arc<Mutex<Map>>,
+}
+
+impl DespawnAirplaneSystem {
+    pub fn new(event_bus: Sender<Event>, map: Arc<Mutex<Map>>) -> Self {
+        Self { event_bus, map }
+    }
+}
+
+impl System for DespawnAirplaneSystem {
+    fn update(&mut self, world: &mut World, _delta: f32) {
+        let mut landed_airplanes = Vec::new();
+        let map = self.map.lock();
+
+        for (entity, (airplane_id, location, flight_plan, tag)) in
+            world.query_mut::<(&AirplaneId, &Location, &mut FlightPlan, &Tag)>()
+        {
+            for airport in map.airports() {
+                if airport.location() != location {
+                    continue;
+                }
+
+                if airport.tag() == *tag {
+                    landed_airplanes.push(entity);
+
+                    self.event_bus
+                        .send(Event::AirplaneLanded(airplane_id.clone()))
+                        .expect("failed to send AirplaneLanded event");
+                } else {
+                    let go_around_node = go_around_procedure(airport, map.grid());
+                    *flight_plan = FlightPlan::new(vec![go_around_node]);
+
+                    self.event_bus
+                        .send(Event::LandingAborted(airplane_id.clone()))
+                        .expect("failed to send LandingAborted event");
+
+                    self.event_bus
+                        .send(Event::FlightPlanUpdated(
+                            airplane_id.clone(),
+                            flight_plan.clone(),
+                        ))
+                        .expect("failed to send FlightPlanUpdated event");
+                }
+            }
+        }
+    }
+}
+
+fn go_around_procedure(airport: &Airport, grid: &Grid<Arc<Node>>) -> Arc<Node> {
+    let neighbors = grid.neighbors(airport.node().longitude(), airport.node().longitude());
+
+    let runway = neighbors
+        .iter()
+        .find(|node| !node.is_restricted())
+        .expect("failed to find runway for airport");
+
+    let direction = (runway.deref() - airport.node().deref()).as_tuple();
+
+    let go_around = grid
+        .get(
+            (airport.node().longitude() as i32 + 2 * direction.0) as u32,
+            (airport.node().latitude() as i32 + 2 * direction.1) as u32,
+        )
+        .expect("failed to find go around node for airport");
+
+    go_around.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DespawnAirplaneSystem>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DespawnAirplaneSystem>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DespawnAirplaneSystem>();
+    }
+}

--- a/game/simulation/src/system/mod.rs
+++ b/game/simulation/src/system/mod.rs
@@ -1,7 +1,9 @@
 use hecs::World;
 
+pub use self::despawn_airplane::*;
 pub use self::spawn_airplane::*;
 
+mod despawn_airplane;
 mod spawn_airplane;
 
 pub trait System {


### PR DESCRIPTION
The previous system to despawn airplanes has been migrated over to this new iteration of the game. Both versions work mostly the same, with the only difference being that the go around procedure is now dynamically executed based on the current state of the map.