### PR TITLE
Move airplanes

### DIFF
--- a/game/simulation/src/bus/event.rs
+++ b/game/simulation/src/bus/event.rs
@@ -8,10 +8,11 @@ use crate::map::{Airport, Grid, Location, Node};
 pub enum Event {
     AirplaneDetected(AirplaneId, Location, FlightPlan, Tag),
     AirplaneLanded(AirplaneId),
+    AirplaneMoved(AirplaneId, Location),
     FlightPlanUpdated(AirplaneId, FlightPlan),
-    LandingAborted(AirplaneId),
     GameStarted(Vec<Airport>, Grid<Arc<Node>>, u32, u32),
     GameStopped,
+    LandingAborted(AirplaneId),
 }
 
 impl Display for Event {

--- a/game/simulation/src/component/flight_plan.rs
+++ b/game/simulation/src/component/flight_plan.rs
@@ -10,6 +10,14 @@ impl FlightPlan {
     pub fn new(flight_plan: Vec<Arc<Node>>) -> Self {
         Self(flight_plan)
     }
+
+    pub fn get(&self) -> &Vec<Arc<Node>> {
+        &self.0
+    }
+
+    pub fn get_mut(&mut self) -> &mut Vec<Arc<Node>> {
+        &mut self.0
+    }
 }
 
 impl Display for FlightPlan {

--- a/game/simulation/src/map/location.rs
+++ b/game/simulation/src/map/location.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::sync::Arc;
 
-use geo::Point;
+use geo::{EuclideanDistance, LineInterpolatePoint, LineString, Point};
 
 use crate::map::Node;
 use crate::TILE_SIZE;
@@ -21,6 +21,23 @@ impl Location {
 
     pub fn y(&self) -> f64 {
         self.0.y()
+    }
+
+    pub fn euclidean_distance(&self, other: &Self) -> f64 {
+        self.0.euclidean_distance(&other.0)
+    }
+
+    pub fn move_towards(&self, other: &Self, distance: f64) -> Option<Self> {
+        let distance_to_other = self.euclidean_distance(other);
+
+        if distance_to_other > distance {
+            return None;
+        }
+
+        let line: LineString = vec![self.0, other.0].into();
+        let fraction = distance / distance_to_other;
+
+        Some(line.line_interpolate_point(fraction)?.into())
     }
 }
 
@@ -42,6 +59,12 @@ impl From<&Node> for Location {
 impl From<&Arc<Node>> for Location {
     fn from(node: &Arc<Node>) -> Self {
         node.deref().into()
+    }
+}
+
+impl From<Point> for Location {
+    fn from(point: Point) -> Self {
+        Location(point)
     }
 }
 

--- a/game/simulation/src/state/running.rs
+++ b/game/simulation/src/state/running.rs
@@ -9,7 +9,7 @@ use crate::behavior::{Commandable, Observable, Updateable};
 use crate::bus::{Command, Event, Receiver, Sender, COMMAND_BUS, EVENT_BUS};
 use crate::map::{MapLoader, Maps};
 use crate::state::Ready;
-use crate::system::{DespawnAirplaneSystem, SpawnAirplaneSystem, System};
+use crate::system::{DespawnAirplaneSystem, MoveAirplaneSystem, SpawnAirplaneSystem, System};
 
 pub struct Running {
     command_bus: Receiver<Command>,
@@ -31,6 +31,7 @@ impl Running {
 
         let systems: Vec<Box<dyn System>> = vec![
             Box::new(DespawnAirplaneSystem::new(EVENT_BUS.0.clone(), map.clone())),
+            Box::new(MoveAirplaneSystem::new(EVENT_BUS.0.clone())),
             Box::new(SpawnAirplaneSystem::new(
                 EVENT_BUS.0.clone(),
                 map,

--- a/game/simulation/src/system/mod.rs
+++ b/game/simulation/src/system/mod.rs
@@ -1,9 +1,11 @@
 use hecs::World;
 
 pub use self::despawn_airplane::*;
+pub use self::move_airplane::*;
 pub use self::spawn_airplane::*;
 
 mod despawn_airplane;
+mod move_airplane;
 mod spawn_airplane;
 
 pub trait System {

--- a/game/simulation/src/system/move_airplane.rs
+++ b/game/simulation/src/system/move_airplane.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use hecs::World;
+
+use crate::bus::{Event, Sender};
+use crate::component::{AirplaneId, FlightPlan};
+use crate::map::{Location, Node};
+use crate::system::System;
+use crate::TILE_SIZE;
+
+const AIRPLANE_SPEED: f32 = TILE_SIZE as f32;
+
+#[derive(Clone, Debug)]
+pub struct MoveAirplaneSystem {
+    event_bus: Sender<Event>,
+}
+
+impl MoveAirplaneSystem {
+    pub fn new(event_bus: Sender<Event>) -> Self {
+        Self { event_bus }
+    }
+}
+
+impl System for MoveAirplaneSystem {
+    fn update(&mut self, world: &mut World, delta: f32) {
+        for (_entity, (airplane_id, location, flight_plan, travelled_route)) in world.query_mut::<(
+            &AirplaneId,
+            &mut Location,
+            &mut FlightPlan,
+            &mut Vec<Arc<Node>>,
+        )>() {
+            let mut distance = AIRPLANE_SPEED * delta;
+
+            while distance > 0.0 {
+                let next_node = flight_plan
+                    .get()
+                    .iter()
+                    .last()
+                    .expect("flight plan must not be empty");
+                let next_location = next_node.into();
+
+                let distance_to_next_location = location.euclidean_distance(&next_location) as f32;
+
+                if distance >= distance_to_next_location {
+                    *location = next_location;
+
+                    let node = flight_plan.get_mut().pop().unwrap();
+                    travelled_route.push(node);
+
+                    distance -= distance_to_next_location;
+
+                    self.event_bus
+                        .send(Event::FlightPlanUpdated(
+                            airplane_id.clone(),
+                            flight_plan.clone(),
+                        ))
+                        .expect("failed to send FlightPlanUpdated event");
+                } else {
+                    *location = location
+                        .move_towards(&next_location, distance as f64)
+                        .expect("failed to move towards next location");
+
+                    distance = 0.0;
+
+                    self.event_bus
+                        .send(Event::AirplaneMoved(airplane_id.clone(), *location))
+                        .expect("failed to send AirplaneMoved event");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<MoveAirplaneSystem>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<MoveAirplaneSystem>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<MoveAirplaneSystem>();
+    }
+}


### PR DESCRIPTION
The system to move airplanes has been migrated to this version of the game. The algorithm is mostly the same, with slight changes to the inner loop and used types. Previously, we could rely on Bevy to calculate some of the 2D geometry. This has been ported to functionality provided by the geo crate now.