### PR TITLE
Detect collisions

### DIFF
--- a/game/simulation/src/bus/event.rs
+++ b/game/simulation/src/bus/event.rs
@@ -6,6 +6,7 @@ use crate::map::{Airport, Grid, Location, Node};
 
 #[derive(Clone, Debug)]
 pub enum Event {
+    AirplaneCollided(AirplaneId, AirplaneId),
     AirplaneDetected(AirplaneId, Location, FlightPlan, Tag),
     AirplaneLanded(AirplaneId),
     AirplaneMoved(AirplaneId, Location),

--- a/game/simulation/src/state/running.rs
+++ b/game/simulation/src/state/running.rs
@@ -9,7 +9,9 @@ use crate::behavior::{Commandable, Observable, Updateable};
 use crate::bus::{Command, Event, Receiver, Sender, COMMAND_BUS, EVENT_BUS};
 use crate::map::{MapLoader, Maps};
 use crate::state::Ready;
-use crate::system::{DespawnAirplaneSystem, MoveAirplaneSystem, SpawnAirplaneSystem, System};
+use crate::system::{
+    DespawnAirplaneSystem, DetectCollisionSystem, MoveAirplaneSystem, SpawnAirplaneSystem, System,
+};
 
 pub struct Running {
     command_bus: Receiver<Command>,
@@ -32,6 +34,7 @@ impl Running {
         let systems: Vec<Box<dyn System>> = vec![
             Box::new(DespawnAirplaneSystem::new(EVENT_BUS.0.clone(), map.clone())),
             Box::new(MoveAirplaneSystem::new(EVENT_BUS.0.clone())),
+            Box::new(DetectCollisionSystem::new(EVENT_BUS.0.clone())),
             Box::new(SpawnAirplaneSystem::new(
                 EVENT_BUS.0.clone(),
                 map,

--- a/game/simulation/src/system/detect_collision.rs
+++ b/game/simulation/src/system/detect_collision.rs
@@ -1,0 +1,70 @@
+use crate::bus::{Event, Sender};
+use crate::component::AirplaneId;
+use crate::map::Location;
+use crate::system::System;
+use hecs::World;
+
+const THRESHOLD: f32 = 24.0;
+
+#[derive(Clone, Debug)]
+pub struct DetectCollisionSystem {
+    event_bus: Sender<Event>,
+}
+
+impl DetectCollisionSystem {
+    pub fn new(event_bus: Sender<Event>) -> Self {
+        Self { event_bus }
+    }
+}
+
+impl System for DetectCollisionSystem {
+    fn update(&mut self, world: &mut World, _delta: f32) {
+        'outer: for (_entity, (airplane_id, location)) in
+            world.query::<(&AirplaneId, &Location)>().iter()
+        {
+            for (_other_entity, (other_airplane_id, other_location)) in
+                world.query::<(&AirplaneId, &Location)>().iter()
+            {
+                if airplane_id == other_airplane_id {
+                    continue;
+                }
+
+                let distance = location.euclidean_distance(other_location) as f32;
+
+                if distance <= THRESHOLD {
+                    self.event_bus
+                        .send(Event::AirplaneCollided(
+                            airplane_id.clone(),
+                            other_airplane_id.clone(),
+                        ))
+                        .expect("failed to send AirplaneCollided event");
+                }
+
+                break 'outer;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DetectCollisionSystem>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DetectCollisionSystem>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DetectCollisionSystem>();
+    }
+}

--- a/game/simulation/src/system/mod.rs
+++ b/game/simulation/src/system/mod.rs
@@ -1,10 +1,12 @@
 use hecs::World;
 
 pub use self::despawn_airplane::*;
+pub use self::detect_collision::*;
 pub use self::move_airplane::*;
 pub use self::spawn_airplane::*;
 
 mod despawn_airplane;
+mod detect_collision;
 mod move_airplane;
 mod spawn_airplane;
 


### PR DESCRIPTION
A new system has been added that detects collisions between airplanes. Contrary to the previous version, the new implementation simply checks the distance between two airplanes and compares it to a predefined threshold.