### PR TITLE
Stop game when two airplanes collide

### DIFF
--- a/game/simulation/src/state/running.rs
+++ b/game/simulation/src/state/running.rs
@@ -70,6 +70,14 @@ impl Display for Running {
     }
 }
 
+impl Drop for Running {
+    fn drop(&mut self) {
+        self.event_bus
+            .send(Event::GameStopped)
+            .expect("failed to send GameStopped event");
+    }
+}
+
 impl From<&Ready> for Running {
     fn from(_state: &Ready) -> Self {
         Self::new()


### PR DESCRIPTION
The simulation watches the event bus and changes its internal state when the collision of two airplanes is detected.