### PR TITLE
Create type for travelled route

### DIFF
--- a/game/simulation/src/component/mod.rs
+++ b/game/simulation/src/component/mod.rs
@@ -1,7 +1,9 @@
 pub use self::airplane_id::*;
 pub use self::flight_plan::*;
 pub use self::tag::*;
+pub use self::travelled_route::*;
 
 mod airplane_id;
 mod flight_plan;
 mod tag;
+mod travelled_route;

--- a/game/simulation/src/component/travelled_route.rs
+++ b/game/simulation/src/component/travelled_route.rs
@@ -1,0 +1,52 @@
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+use crate::map::Node;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct TravelledRoute(Vec<Arc<Node>>);
+
+impl TravelledRoute {
+    pub fn new(travelled_route: Vec<Arc<Node>>) -> Self {
+        Self(travelled_route)
+    }
+
+    pub fn get_mut(&mut self) -> &mut Vec<Arc<Node>> {
+        &mut self.0
+    }
+}
+
+impl Display for TravelledRoute {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TravelledRoute")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let travelled_route = TravelledRoute::default();
+        assert_eq!("TravelledRoute", travelled_route.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<TravelledRoute>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<TravelledRoute>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<TravelledRoute>();
+    }
+}

--- a/game/simulation/src/system/move_airplane.rs
+++ b/game/simulation/src/system/move_airplane.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
-
 use hecs::World;
 
 use crate::bus::{Event, Sender};
-use crate::component::{AirplaneId, FlightPlan};
-use crate::map::{Location, Node};
+use crate::component::{AirplaneId, FlightPlan, TravelledRoute};
+use crate::map::Location;
 use crate::system::System;
 use crate::TILE_SIZE;
 
@@ -27,7 +25,7 @@ impl System for MoveAirplaneSystem {
             &AirplaneId,
             &mut Location,
             &mut FlightPlan,
-            &mut Vec<Arc<Node>>,
+            &mut TravelledRoute,
         )>() {
             let mut distance = AIRPLANE_SPEED * delta;
 
@@ -45,7 +43,7 @@ impl System for MoveAirplaneSystem {
                     *location = next_location;
 
                     let node = flight_plan.get_mut().pop().unwrap();
-                    travelled_route.push(node);
+                    travelled_route.get_mut().push(node);
 
                     distance -= distance_to_next_location;
 

--- a/game/simulation/src/system/spawn_airplane.rs
+++ b/game/simulation/src/system/spawn_airplane.rs
@@ -8,7 +8,7 @@ use rand::prelude::*;
 use time::{Duration, Instant};
 
 use crate::bus::{Event, Sender};
-use crate::component::{FlightPlan, Tag};
+use crate::component::{FlightPlan, Tag, TravelledRoute};
 use crate::map::{Location, Map, Node, MAP_BORDER_WIDTH};
 use crate::system::System;
 use crate::util::AirplaneIdGenerator;
@@ -154,7 +154,7 @@ impl System for SpawnAirplaneSystem {
         let id = self.airplane_id_generator.generate();
         let location: Location = spawn.start_node.deref().into();
         let flight_plan = FlightPlan::new(vec![spawn.first_node]);
-        let travelled_route = vec![spawn.start_node];
+        let travelled_route = TravelledRoute::new(vec![spawn.start_node]);
         let tag = self.random_tag();
 
         world.spawn((
@@ -173,8 +173,9 @@ impl System for SpawnAirplaneSystem {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::bus::channel;
+
+    use super::*;
 
     #[test]
     fn trait_display() {


### PR DESCRIPTION
With the ECS, having a discrete type for the travelled route in place of just a Vector makes queries more robust and descriptive.