### PR TITLE
Migrate API layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
+name = "api"
+version = "0.4.0-dev"
+dependencies = [
+ "auto-traffic-control",
+ "dashmap",
+ "parking_lot",
+ "prost",
+ "semver",
+ "simulation",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +190,19 @@ name = "critical-section"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+
+[[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "debug-client"
@@ -694,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -726,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -873,6 +901,7 @@ checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 name = "simulation"
 version = "0.4.0-dev"
 dependencies = [
+ "auto-traffic-control",
  "geo",
  "hecs",
  "lazy_static",
@@ -1028,6 +1057,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "examples/rust",
+    "game/api",
     "game/simulation",
     "sdk/rust",
     "utilities/debug-client",

--- a/game/api/Cargo.toml
+++ b/game/api/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "api"
+description = "gRPC server for Auto Traffic Control"
+
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+
+homepage.workspace = true
+repository.workspace = true
+
+publish = false
+
+[dependencies]
+auto-traffic-control = { path = "../../sdk/rust", version = "0.4.0-dev", features = ["server"] }
+simulation = { path = "../simulation", version = "0.4.0-dev" }
+
+dashmap = "5"
+parking_lot = "0.12"
+prost = "0.11"
+semver = "1"
+tokio-stream = { version = "0.1", features = ["sync"] }
+tonic = "0.8"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/game/api/src/airplane.rs
+++ b/game/api/src/airplane.rs
@@ -1,0 +1,105 @@
+use std::ops::Deref;
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+
+use auto_traffic_control::v1::update_flight_plan_error::ValidationError;
+use auto_traffic_control::v1::update_flight_plan_response::Payload;
+use auto_traffic_control::v1::{
+    GetAirplaneRequest, GetAirplaneResponse, UpdateFlightPlanError, UpdateFlightPlanRequest,
+    UpdateFlightPlanResponse, UpdateFlightPlanSuccess,
+};
+use simulation::prelude::*;
+
+use crate::store::Store;
+
+#[derive(Clone, Debug)]
+pub struct AirplaneService {
+    command_bus: Sender<Command>,
+    store: Arc<Store>,
+}
+
+impl AirplaneService {
+    pub fn new(command_bus: Sender<Command>, store: Arc<Store>) -> Self {
+        Self { command_bus, store }
+    }
+}
+
+#[tonic::async_trait]
+impl auto_traffic_control::v1::airplane_service_server::AirplaneService for AirplaneService {
+    async fn get_airplane(
+        &self,
+        request: Request<GetAirplaneRequest>,
+    ) -> Result<Response<GetAirplaneResponse>, Status> {
+        let id = request.into_inner().id;
+
+        if let Some(airplane) = self.store.airplanes().get(&id) {
+            Ok(Response::new(GetAirplaneResponse {
+                airplane: Some(airplane.clone()),
+            }))
+        } else {
+            Err(Status::not_found(format!(
+                "No airplane with id {id} was found"
+            )))
+        }
+    }
+
+    async fn update_flight_plan(
+        &self,
+        request: Request<UpdateFlightPlanRequest>,
+    ) -> Result<Response<UpdateFlightPlanResponse>, Status> {
+        let request = request.into_inner();
+        let id = request.id;
+
+        let airplane = match self.store.airplanes().get(&id) {
+            Some(airplane) => airplane,
+            None => {
+                return Err(Status::not_found(format!(
+                    "No airplane with id {id} was found"
+                )));
+            }
+        };
+
+        let previous_flight_plan = airplane.flight_plan.clone().into();
+        let new_flight_plan: FlightPlan = request.flight_plan.into();
+
+        let grid_guard = self.store.grid().lock();
+        let grid = match grid_guard.deref() {
+            Some(grid) => grid,
+            None => {
+                return Err(Status::not_found(
+                    "No grid was found. The game has not started yet.".to_string(),
+                ));
+            }
+        };
+
+        if let Err(errors) = new_flight_plan.validate(&previous_flight_plan, grid) {
+            let errors = errors
+                .iter()
+                .map(|error| {
+                    let error: ValidationError = (*error).into();
+                    error.into()
+                })
+                .collect();
+
+            return Ok(Response::new(UpdateFlightPlanResponse {
+                payload: Some(Payload::Error(UpdateFlightPlanError { errors })),
+            }));
+        };
+
+        if self
+            .command_bus
+            .send(Command::UpdateFlightPlan(
+                AirplaneId::new(id),
+                new_flight_plan,
+            ))
+            .is_err()
+        {
+            return Err(Status::internal("failed to queue command"));
+        }
+
+        Ok(Response::new(UpdateFlightPlanResponse {
+            payload: Some(Payload::Success(UpdateFlightPlanSuccess {})),
+        }))
+    }
+}

--- a/game/api/src/atc.rs
+++ b/game/api/src/atc.rs
@@ -1,0 +1,72 @@
+use semver::Version as SemVer;
+use tonic::{Request, Response, Status};
+
+use auto_traffic_control::v1::{GetVersionRequest, GetVersionResponse, Version};
+
+pub struct AtcService;
+
+#[tonic::async_trait]
+impl auto_traffic_control::v1::atc_service_server::AtcService for AtcService {
+    async fn get_version(
+        &self,
+        _request: Request<GetVersionRequest>,
+    ) -> Result<Response<GetVersionResponse>, Status> {
+        let semver = SemVer::parse(env!("CARGO_PKG_VERSION")).unwrap();
+        let version = Version {
+            major: semver.major,
+            minor: semver.minor,
+            patch: semver.patch,
+            pre: semver.pre.to_string(),
+        };
+
+        Ok(Response::new(GetVersionResponse {
+            version: Some(version),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::Request;
+
+    use auto_traffic_control::v1::atc_service_server::AtcService as ServiceTrait;
+    use auto_traffic_control::v1::GetVersionRequest;
+
+    use super::AtcService;
+
+    #[tokio::test]
+    async fn get_version() {
+        let response = AtcService
+            .get_version(Request::new(GetVersionRequest {}))
+            .await
+            .unwrap();
+
+        let version = response.into_inner().version.unwrap();
+
+        assert_eq!(
+            env!("CARGO_PKG_VERSION_MAJOR").parse::<u64>().unwrap(),
+            version.major
+        );
+        assert_eq!(
+            env!("CARGO_PKG_VERSION_MINOR").parse::<u64>().unwrap(),
+            version.minor
+        );
+        assert_eq!(
+            env!("CARGO_PKG_VERSION_PATCH").parse::<u64>().unwrap(),
+            version.patch
+        );
+        assert_eq!(env!("CARGO_PKG_VERSION_PRE"), version.pre);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AtcService>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AtcService>();
+    }
+}

--- a/game/api/src/event.rs
+++ b/game/api/src/event.rs
@@ -1,0 +1,43 @@
+use std::pin::Pin;
+
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
+use tonic::codegen::futures_core::Stream;
+use tonic::{Request, Response, Status};
+
+use auto_traffic_control::v1::{StreamRequest, StreamResponse};
+use simulation::prelude::*;
+
+#[derive(Debug)]
+pub struct EventService {
+    event_receiver: Receiver<Event>,
+}
+
+impl EventService {
+    pub fn new(event_receiver: Receiver<Event>) -> Self {
+        Self { event_receiver }
+    }
+}
+
+#[tonic::async_trait]
+impl auto_traffic_control::v1::event_service_server::EventService for EventService {
+    type StreamStream =
+        Pin<Box<dyn Stream<Item = Result<StreamResponse, Status>> + Send + Sync + 'static>>;
+
+    async fn stream(
+        &self,
+        _request: Request<StreamRequest>,
+    ) -> Result<Response<Self::StreamStream>, Status> {
+        let stream =
+            BroadcastStream::new(self.event_receiver.resubscribe().into()).filter_map(|event| {
+                let event = match event {
+                    Ok(event) => Some(event.into()),
+                    Err(_) => None,
+                };
+
+                event.map(|event| Ok(StreamResponse { event: Some(event) }))
+            });
+
+        Ok(Response::new(Box::pin(stream) as Self::StreamStream))
+    }
+}

--- a/game/api/src/game.rs
+++ b/game/api/src/game.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+
+use auto_traffic_control::v1::{
+    GetGameStateRequest, GetGameStateResponse, StartGameRequest, StartGameResponse,
+};
+use simulation::prelude::*;
+
+use crate::store::{SharedGameState, Store};
+
+#[derive(Clone, Debug)]
+pub struct GameService {
+    command_bus: Sender<Command>,
+    game_state: SharedGameState,
+}
+
+impl GameService {
+    pub fn new(command_bus: Sender<Command>, store: Arc<Store>) -> Self {
+        Self {
+            command_bus,
+            game_state: store.game_state().clone(),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl auto_traffic_control::v1::game_service_server::GameService for GameService {
+    async fn get_game_state(
+        &self,
+        _request: Request<GetGameStateRequest>,
+    ) -> Result<Response<GetGameStateResponse>, Status> {
+        let game_state = self.game_state.lock();
+
+        Ok(Response::new(GetGameStateResponse {
+            game_state: (*game_state).into(),
+        }))
+    }
+
+    async fn start_game(
+        &self,
+        _request: Request<StartGameRequest>,
+    ) -> Result<Response<StartGameResponse>, Status> {
+        if self.command_bus.send(Command::StartGame).is_err() {
+            return Err(Status::internal("failed to queue command"));
+        }
+
+        Ok(Response::new(StartGameResponse {}))
+    }
+}

--- a/game/api/src/lib.rs
+++ b/game/api/src/lib.rs
@@ -1,0 +1,63 @@
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use tonic::transport::{Error, Server as GrpcServer};
+
+use auto_traffic_control::v1::airplane_service_server::AirplaneServiceServer;
+use auto_traffic_control::v1::atc_service_server::AtcServiceServer;
+use auto_traffic_control::v1::event_service_server::EventServiceServer;
+use auto_traffic_control::v1::game_service_server::GameServiceServer;
+use auto_traffic_control::v1::map_service_server::MapServiceServer;
+use simulation::prelude::*;
+
+use self::airplane::AirplaneService;
+use self::atc::AtcService;
+use self::event::EventService;
+use self::game::GameService;
+use self::map::MapService;
+pub use self::store::Store;
+
+mod airplane;
+mod atc;
+mod event;
+mod game;
+mod map;
+mod store;
+
+const INTERFACE_VARIABLE: &str = "AUTO_TRAFFIC_CONTROL_INTERFACE";
+
+pub struct Api;
+
+impl Api {
+    pub async fn serve(
+        command_sender: Sender<Command>,
+        event_receiver: Receiver<Event>,
+        store: Arc<Store>,
+    ) -> Result<(), Error> {
+        GrpcServer::builder()
+            .add_service(AirplaneServiceServer::new(AirplaneService::new(
+                command_sender.clone(),
+                store.clone(),
+            )))
+            .add_service(AtcServiceServer::new(AtcService))
+            .add_service(EventServiceServer::new(EventService::new(event_receiver)))
+            .add_service(GameServiceServer::new(GameService::new(
+                command_sender,
+                store.clone(),
+            )))
+            .add_service(MapServiceServer::new(MapService::new(store)))
+            .serve(Self::address_or_default())
+            .await
+    }
+
+    fn address_or_default() -> SocketAddr {
+        if let Ok(address_string) = std::env::var(INTERFACE_VARIABLE) {
+            if let Ok(address) = SocketAddr::from_str(&address_string) {
+                return address;
+            }
+        }
+
+        SocketAddr::new(IpAddr::from([0, 0, 0, 0]), 4747)
+    }
+}

--- a/game/api/src/map.rs
+++ b/game/api/src/map.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+
+use auto_traffic_control::v1::{
+    GetMapRequest, GetMapResponse, NodeToPointRequest, NodeToPointResponse,
+};
+use simulation::prelude::*;
+
+use crate::store::Store;
+
+#[derive(Clone, Debug, Default)]
+pub struct MapService {
+    store: Arc<Store>,
+}
+
+impl MapService {
+    pub fn new(store: Arc<Store>) -> Self {
+        Self { store }
+    }
+}
+
+#[tonic::async_trait]
+impl auto_traffic_control::v1::map_service_server::MapService for MapService {
+    async fn get_map(
+        &self,
+        _request: Request<GetMapRequest>,
+    ) -> Result<Response<GetMapResponse>, Status> {
+        let map = self.store.map().lock().clone();
+        Ok(Response::new(GetMapResponse { map }))
+    }
+
+    async fn node_to_point(
+        &self,
+        request: Request<NodeToPointRequest>,
+    ) -> Result<Response<NodeToPointResponse>, Status> {
+        if let Some(node) = request.into_inner().node {
+            let location: Location = (&node).into();
+
+            Ok(Response::new(NodeToPointResponse {
+                point: Some(location.into()),
+            }))
+        } else {
+            Err(Status::invalid_argument("must provide a Node"))
+        }
+    }
+}

--- a/game/api/src/store.rs
+++ b/game/api/src/store.rs
@@ -1,0 +1,170 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use auto_traffic_control::v1::get_game_state_response::GameState;
+use auto_traffic_control::v1::{Airplane, Map};
+use simulation::prelude::*;
+
+pub type SharedGameState = Arc<Mutex<GameState>>;
+pub type SharedGrid = Arc<Mutex<Option<Grid<Arc<Node>>>>>;
+pub type SharedMap = Arc<Mutex<Option<Map>>>;
+
+#[derive(Clone, Debug)]
+pub struct Store {
+    airplanes: DashMap<String, Airplane>,
+    game_state: SharedGameState,
+    map: SharedMap,
+    grid: SharedGrid,
+}
+
+impl Store {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn daemonize(mut event_bus: Receiver<Event>, store: Arc<Store>) {
+        while let Ok(event) = event_bus.recv().await {
+            store.update(event);
+        }
+    }
+
+    pub fn airplanes(&self) -> &DashMap<String, Airplane> {
+        &self.airplanes
+    }
+
+    pub fn game_state(&self) -> &SharedGameState {
+        &self.game_state
+    }
+
+    pub fn map(&self) -> &SharedMap {
+        &self.map
+    }
+
+    pub fn grid(&self) -> &SharedGrid {
+        &self.grid
+    }
+
+    fn update(&self, event: Event) {
+        match event {
+            Event::AirplaneDetected(id, location, flight_plan, tag) => {
+                self.insert_airplane(id, location, flight_plan, tag)
+            }
+            Event::AirplaneLanded(id) => self.remove_airplane(id),
+            Event::AirplaneMoved(id, location) => self.move_airplane(id, location),
+            Event::FlightPlanUpdated(id, flight_plan) => self.update_flight_plan(id, flight_plan),
+            Event::GameStarted(airports, grid, width, height) => {
+                self.start_game(airports, grid, width, height)
+            }
+            Event::GameStopped(_) => self.reset(),
+            _ => {}
+        }
+    }
+
+    fn insert_airplane(
+        &self,
+        id: AirplaneId,
+        location: Location,
+        flight_plan: FlightPlan,
+        tag: Tag,
+    ) {
+        let tag: auto_traffic_control::v1::Tag = tag.into();
+
+        self.airplanes().insert(
+            id.get().into(),
+            Airplane {
+                id: id.into(),
+                point: Some(location.into()),
+                flight_plan: flight_plan.into(),
+                tag: tag.into(),
+            },
+        );
+    }
+
+    fn remove_airplane(&self, id: AirplaneId) {
+        self.airplanes().remove(id.get());
+    }
+
+    fn move_airplane(&self, id: AirplaneId, location: Location) {
+        if let Some(mut airplane) = self.airplanes().get_mut(id.get()) {
+            airplane.point = Some(location.into());
+        }
+    }
+
+    fn update_flight_plan(&self, id: AirplaneId, flight_plan: FlightPlan) {
+        if let Some(mut airplane) = self.airplanes().get_mut(id.get()) {
+            airplane.flight_plan = flight_plan.into();
+        }
+    }
+
+    fn start_game(&self, airports: Vec<Airport>, grid: Grid<Arc<Node>>, width: u32, height: u32) {
+        let mut game_started = self.game_state().lock();
+        *game_started = GameState::Running;
+
+        let airports = airports.into_iter().map(|airport| airport.into()).collect();
+        let routing_grid = grid
+            .elements()
+            .iter()
+            .map(|node| (*node.clone()).into())
+            .collect();
+
+        let mut map_guard = self.map().lock();
+        *map_guard = Some(Map {
+            airports,
+            routing_grid,
+            width,
+            height,
+        });
+
+        let mut grid_guard = self.grid().lock();
+        *grid_guard = Some(grid);
+    }
+
+    fn reset(&self) {
+        self.airplanes().clear();
+
+        let mut map_guard = self.map().lock();
+        *map_guard = None;
+
+        let mut grid_guard = self.grid().lock();
+        *grid_guard = None;
+
+        let mut game_started = self.game_state().lock();
+        *game_started = GameState::Ready;
+    }
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Self {
+            airplanes: DashMap::new(),
+            game_state: Arc::new(Mutex::new(GameState::Ready)),
+            map: Arc::new(Mutex::new(None)),
+            grid: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Store;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Store>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Store>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Store>();
+    }
+}

--- a/game/simulation/Cargo.toml
+++ b/game/simulation/Cargo.toml
@@ -12,6 +12,8 @@ repository.workspace = true
 publish = false
 
 [dependencies]
+auto-traffic-control = { path = "../../sdk/rust", version = "0.4.0-dev", features = ["server"] }
+
 geo = "0.23"
 hecs = "0.9"
 lazy_static = "1"

--- a/game/simulation/src/bus/event.rs
+++ b/game/simulation/src/bus/event.rs
@@ -1,3 +1,4 @@
+use auto_traffic_control::v1::{Airplane, Map};
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
@@ -19,6 +20,70 @@ pub enum Event {
 impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "Event")
+    }
+}
+
+impl From<Event> for auto_traffic_control::v1::stream_response::Event {
+    fn from(event: Event) -> Self {
+        match event {
+            Event::AirplaneCollided(id1, id2) => {
+                Self::AirplaneCollided(auto_traffic_control::v1::AirplaneCollided {
+                    id1: id1.into(),
+                    id2: id2.into(),
+                })
+            }
+            Event::AirplaneDetected(id, location, flight_plan, tag) => {
+                let tag: auto_traffic_control::v1::Tag = tag.into();
+
+                Self::AirplaneDetected(auto_traffic_control::v1::AirplaneDetected {
+                    airplane: Some(Airplane {
+                        id: id.to_string(),
+                        point: Some(location.into()),
+                        flight_plan: flight_plan.into(),
+                        tag: tag.into(),
+                    }),
+                })
+            }
+            Event::AirplaneLanded(id) => {
+                Self::AirplaneLanded(auto_traffic_control::v1::AirplaneLanded {
+                    id: id.to_string(),
+                })
+            }
+            Event::AirplaneMoved(id, location) => {
+                Self::AirplaneMoved(auto_traffic_control::v1::AirplaneMoved {
+                    id: id.to_string(),
+                    point: Some(location.into()),
+                })
+            }
+            Event::FlightPlanUpdated(id, flight_plan) => {
+                Self::FlightPlanUpdated(auto_traffic_control::v1::FlightPlanUpdated {
+                    id: id.to_string(),
+                    flight_plan: flight_plan.into(),
+                })
+            }
+            Event::GameStarted(airports, grid, width, height) => {
+                Self::GameStarted(auto_traffic_control::v1::GameStarted {
+                    map: Some(Map {
+                        airports: airports.into_iter().map(|airport| airport.into()).collect(),
+                        routing_grid: grid
+                            .elements()
+                            .iter()
+                            .map(|node| (*node.clone()).into())
+                            .collect(),
+                        width,
+                        height,
+                    }),
+                })
+            }
+            Event::GameStopped(score) => {
+                Self::GameStopped(auto_traffic_control::v1::GameStopped { score })
+            }
+            Event::LandingAborted(id) => {
+                Self::LandingAborted(auto_traffic_control::v1::LandingAborted {
+                    id: id.to_string(),
+                })
+            }
+        }
     }
 }
 

--- a/game/simulation/src/bus/receiver.rs
+++ b/game/simulation/src/bus/receiver.rs
@@ -32,6 +32,12 @@ impl<T> Display for Receiver<T> {
     }
 }
 
+impl<T> From<Receiver<T>> for tokio::sync::broadcast::Receiver<T> {
+    fn from(receiver: Receiver<T>) -> Self {
+        receiver.receiver
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/game/simulation/src/component/airplane_id.rs
+++ b/game/simulation/src/component/airplane_id.rs
@@ -25,6 +25,18 @@ impl Display for AirplaneId {
     }
 }
 
+impl From<&str> for AirplaneId {
+    fn from(id: &str) -> Self {
+        Self(id.to_string())
+    }
+}
+
+impl From<AirplaneId> for String {
+    fn from(id: AirplaneId) -> Self {
+        id.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/game/simulation/src/component/tag.rs
+++ b/game/simulation/src/component/tag.rs
@@ -15,6 +15,15 @@ impl Display for Tag {
     }
 }
 
+impl From<Tag> for auto_traffic_control::v1::Tag {
+    fn from(tag: Tag) -> Self {
+        match tag {
+            Tag::Blue => Self::Blue,
+            Tag::Red => Self::Red,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/game/simulation/src/lib.rs
+++ b/game/simulation/src/lib.rs
@@ -28,6 +28,12 @@ mod state;
 mod system;
 mod util;
 
+pub mod prelude {
+    pub use crate::bus::{channel, Command, Event, Receiver, Sender};
+    pub use crate::component::{AirplaneId, FlightPlan, FlightPlanError, Tag};
+    pub use crate::map::{Airport, Grid, Location, Node};
+}
+
 const TILE_SIZE: u32 = 64;
 
 pub struct Simulation {

--- a/game/simulation/src/map/airport.rs
+++ b/game/simulation/src/map/airport.rs
@@ -41,6 +41,17 @@ impl Display for Airport {
     }
 }
 
+impl From<Airport> for auto_traffic_control::v1::Airport {
+    fn from(airport: Airport) -> Self {
+        let tag: auto_traffic_control::v1::Tag = airport.tag.into();
+
+        Self {
+            node: Some((*airport.node).into()),
+            tag: tag.into(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/game/simulation/src/map/grid.rs
+++ b/game/simulation/src/map/grid.rs
@@ -22,6 +22,10 @@ impl<T> Grid<T> {
         self.elements.get((y * self.width + x) as usize)
     }
 
+    pub fn elements(&self) -> &Vec<T> {
+        &self.elements
+    }
+
     pub fn width(&self) -> u32 {
         self.width
     }

--- a/game/simulation/src/map/location.rs
+++ b/game/simulation/src/map/location.rs
@@ -47,6 +47,15 @@ impl Display for Location {
     }
 }
 
+impl From<&auto_traffic_control::v1::Node> for Location {
+    fn from(node: &auto_traffic_control::v1::Node) -> Self {
+        let x = node.longitude as u32 * TILE_SIZE;
+        let y = node.latitude as u32 * TILE_SIZE;
+
+        Self::new(x as f64, y as f64)
+    }
+}
+
 impl From<&Node> for Location {
     fn from(node: &Node) -> Self {
         let x = node.longitude() * TILE_SIZE;
@@ -65,6 +74,15 @@ impl From<&Arc<Node>> for Location {
 impl From<Point> for Location {
     fn from(point: Point) -> Self {
         Location(point)
+    }
+}
+
+impl From<Location> for auto_traffic_control::v1::Point {
+    fn from(location: Location) -> Self {
+        Self {
+            x: location.x() as i32,
+            y: location.y() as i32,
+        }
     }
 }
 

--- a/game/simulation/src/map/node.rs
+++ b/game/simulation/src/map/node.rs
@@ -44,6 +44,26 @@ impl Display for Node {
     }
 }
 
+impl From<Node> for auto_traffic_control::v1::Node {
+    fn from(node: Node) -> Self {
+        Self {
+            longitude: node.longitude() as i32,
+            latitude: node.latitude() as i32,
+            restricted: node.is_restricted(),
+        }
+    }
+}
+
+impl From<&auto_traffic_control::v1::Node> for Node {
+    fn from(node: &auto_traffic_control::v1::Node) -> Self {
+        Self {
+            longitude: node.longitude as u32,
+            latitude: node.latitude as u32,
+            restricted: node.restricted,
+        }
+    }
+}
+
 impl ops::Sub for &Node {
     type Output = Direction;
 


### PR DESCRIPTION
The API layer has been copied into the project from the previous implementation. The services are largely unchanged, but the translation between internal and external data representations has been completely rewritten.

Because the lifecycle of some entities has changed, namely the map and the grid, the tests that had been written for the API don't work anymore. These will be refactored and added again in a later commit.