### PR TITLE
Fix spawn rate of airplanes

### DIFF
--- a/game/simulation/src/system/spawn_airplane.rs
+++ b/game/simulation/src/system/spawn_airplane.rs
@@ -135,6 +135,8 @@ impl System for SpawnAirplaneSystem {
             tag,
         ));
 
+        self.last_spawn = Instant::now();
+
         self.event_bus
             .send(Event::AirplaneDetected(id, location, flight_plan, tag))
             .expect("failed to send AirplaneDetected event");
@@ -197,6 +199,7 @@ mod tests {
             FlightPlan::new(vec![Arc::new(Node::new(3, 1, false))]),
             flight_plan
         );
+        assert!(system.last_spawn > Instant::now() - Duration::seconds(2));
     }
 
     #[test]


### PR DESCRIPTION
Airplanes were spawned at a rate of 1 airplane per frame due to a bug in the code. After spawning an airplane, the last spawn time was never set and thus always triggered a new spawn.