### PR TITLE
Publish Docker image for headless mode

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+---
+name: Docker
+
+"on":
+  push:
+    branches:
+      - "master"
+    tags:
+      - "v*"
+  pull_request:
+
+jobs:
+  headless:
+    name: Build and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Collect metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          file: game/cli/Dockerfile
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/game/cli/Dockerfile
+++ b/game/cli/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1 as builder
+
+WORKDIR /usr/src/auto-traffic-control
+
+RUN apt-get update && apt-get install -y \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN cargo install --path game/cli
+
+FROM debian:buster-slim
+
+RUN apt-get update && apt-get install -y \
+    dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/cargo/bin/cli /usr/local/bin/auto-traffic-control
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["auto-traffic-control"]


### PR DESCRIPTION
To make it easier for players to run the game in headless mode, a Docker image is now being built and published to GitHub's container registry. The image contains the game's executable, and launches the simulation when a container is created.