### PR TITLE
Make Direction public

### DIFF
--- a/game/simulation/src/lib.rs
+++ b/game/simulation/src/lib.rs
@@ -31,7 +31,7 @@ mod util;
 pub mod prelude {
     pub use crate::bus::{channel, Command, Event, Receiver, Sender};
     pub use crate::component::{AirplaneId, FlightPlan, FlightPlanError, Tag};
-    pub use crate::map::{Airport, Grid, Location, Node};
+    pub use crate::map::{Airport, Direction, Grid, Location, Node};
 }
 
 const TILE_SIZE: u32 = 64;


### PR DESCRIPTION
The `Direction` enum has not yet been included in the simulation's public API, despite being using in the `ops::Sub` implementation for nodes.