### PR TITLE
Fix distance for collision detection

### DIFF
--- a/game/simulation/src/system/detect_collision.rs
+++ b/game/simulation/src/system/detect_collision.rs
@@ -4,8 +4,9 @@ use crate::bus::{Event, Sender};
 use crate::component::AirplaneId;
 use crate::map::Location;
 use crate::system::System;
+use crate::TILE_SIZE;
 
-const THRESHOLD: f32 = 24.0;
+const THRESHOLD: f32 = TILE_SIZE as f32 * 0.75;
 
 #[derive(Clone, Debug)]
 pub struct DetectCollisionSystem {


### PR DESCRIPTION
The previous setting was from an earlier iteration that used 32x32 tiles. Since we are now using 64x64 tiles, we are bumping the threshold as well.