### PR TITLE
Fix branch name in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Docker
 "on":
   push:
     branches:
-      - "master"
+      - "main"
     tags:
       - "v*"
   pull_request:
@@ -26,7 +26,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
When copy & pasting the workflow from the documentation, we missed that it referred to the `master` branch. We are using `main` as the default branch, and the configuration has been changed to reflect that.